### PR TITLE
Skip copying dortfiles from /public/

### DIFF
--- a/lib/perron/site/builder/public_files.rb
+++ b/lib/perron/site/builder/public_files.rb
@@ -30,7 +30,7 @@ module Perron
         private
 
         def paths
-          @paths ||= Dir.glob("#{@public_dir}/*", File::FNM_DOTMATCH).reject do |path|
+          @paths ||= Dir.glob(File.join(@public_dir, "*")).reject do |path|
             Set.new(Perron.configuration.exclude_from_public + %w[. ..]).include?(File.basename(path))
           end
         end


### PR DESCRIPTION
It is more annying than useful. Can possibly add an implicit/include list/array later if there are use cases for it.