### PR TITLE
Make `resources` an alias of `all`

### DIFF
--- a/lib/perron/site/collection.rb
+++ b/lib/perron/site/collection.rb
@@ -16,6 +16,7 @@ module Perron
         resource_class.new(file_path)
       end.select(&:published?)
     end
+    alias_method :resources, :all
 
     def find(slug, resource_class = Resource)
       resource = all(resource_class).find { it.slug == slug }


### PR DESCRIPTION
Just found myself doing `Site::Collection("platforms").resources`. Makes more sense than `Site::Collection("platforms").all`