### PR TITLE
Added proxy class for Data

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,9 +98,9 @@ This is useful for populating features, team members, or any other repeated data
 
 ### Usage
 
-To use a data file, instantiate `Perron::Data` with the basename of the file and iterate over the result.
+To use a data file, instantiate `Perron::Site.data` with the basename of the file and iterate over the result.
 ```erb
-<% Perron::Data.new("features").each do |feature| %>
+<% Perron::Site.data.features.each do |feature| %>
   <h4><%= feature.name %></h4>
   <p><%= feature.description %></p>
 <% end %>
@@ -109,7 +109,7 @@ To use a data file, instantiate `Perron::Data` with the basename of the file and
 ### File Location and Formats
 
 By default, Perron looks up `app/content/data/` for files with a `.yml`, `.json`, or `.csv` extension.
-For a `new("features")` call, it would find `features.yml`, `features.json`, or `features.csv`. You can also provide a full, absolute path to any data file.
+For a `features` call, it would find `features.yml`, `features.json`, or `features.csv`. You can also provide a path to any data file, via `Perron::Data.new("path/to/data.json")`.
 
 ### Accessing Data
 
@@ -123,7 +123,6 @@ feature[:name]
 ## Metatags
 
 The `meta_tags` helper automatically generates SEO and social sharing meta tags for your pages.
-
 
 ### Usage
 

--- a/lib/perron/site.rb
+++ b/lib/perron/site.rb
@@ -4,6 +4,7 @@ require "perron/site/builder"
 require "perron/site/collection"
 require "perron/site/resource"
 require "perron/site/data"
+require "perron/site/data/proxy"
 
 module Perron
   module Site
@@ -29,8 +30,8 @@ module Perron
 
     def collection(name) = Collection.new(name)
 
-    def data(name)
-      Perron::Data.new(name)
+    def data(name = nil)
+      (name && Perron::Data.new(name)) || Perron::Data::Proxy.new
     end
   end
 end

--- a/lib/perron/site/data/proxy.rb
+++ b/lib/perron/site/data/proxy.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Perron
+  class Data
+    class Proxy
+      def method_missing(method_name, *arguments, &block)
+        raise ArgumentError, "Data `#{method_name}` does not accept arguments" if arguments.any?
+
+        Perron::Data.new(method_name.to_s)
+      end
+
+      def respond_to_missing?(method_name, include_private = false)
+        true
+      end
+    end
+  end
+end


### PR DESCRIPTION
This will allow for cleaner data lookup, like `Perron::Site.data.features`, instead of `Perron::Site.data("features")`. Though the latter is still supported.