### PR TITLE
Add erbify helper for granular ERB processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,71 @@ end
 ```
 
 
+### Embed Ruby
+
+Perron provides flexible options for embedding dynamic Ruby code in your content using ERB.
+
+
+#### 1. File extension
+
+Any content file with a `.erb` extension (e.g., `about.erb`) will automatically have its content processed as ERB.
+
+
+#### 2. Frontmatter
+
+You can enable ERB processing on a per-file basis, even for standard `.md` files, by adding `erb: true` to the file's frontmatter.
+```markdown
+---
+title: Dynamic Page
+erb: true
+---
+
+This entire page will be processed by ERB.
+The current time is: <%= Time.current.to_fs(:long_ordinal) %>.
+```
+
+
+#### 3. `erbify` helper
+
+For the most granular control, the `erbify` helper allows to process specific sections of a file as ERB.
+This is ideal for generating dynamic content like lists or tables from your resource's metadata, without needing to enable ERB for the entire file. The `erbify` helper can be used with a string or, more commonly, a block.
+
+**Example:** Generating a list from frontmatter data in a standard `.md` file.
+```markdown
+---
+title: Features
+features:
+  - Rails based
+  - SEO friendly
+  - Markdown first
+  - ERB support
+---
+
+Check out our amazing features:
+
+<%= erbify do %>
+  <ul>
+    <% @resource.metadata.features.each do |feature| %>
+      <li>
+        <%= feature %>
+      </li>
+    <% end %>
+  </ul>
+<% end %>
+```
+
+**Result:**
+```html
+<p>Check out our amazing features:</p>
+<ul>
+  <li>Rails based</li>
+  <li>SEO friendly</li>
+  <li>Markdown first</li>
+  <li>ERB support</li>
+</ul>
+```
+
+
 ## Data Files
 
 Perron can consume structured data from YML, JSON, or CSV files, making them available within your templates.

--- a/app/helpers/perron/erb_helper.rb
+++ b/app/helpers/perron/erb_helper.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Perron
+  module ErbHelper
+    def erbify(content = nil, options = {}, &block)
+      Perron::Resource::Renderer.erb(content || capture(&block).strip_heredoc, {resource: @resource})
+    end
+  end
+end

--- a/lib/perron/site/resource.rb
+++ b/lib/perron/site/resource.rb
@@ -5,6 +5,7 @@ require "perron/site/resource/core"
 require "perron/site/resource/class_methods"
 require "perron/site/resource/publishable"
 require "perron/site/resource/related"
+require "perron/site/resource/renderer"
 require "perron/site/resource/slug"
 require "perron/site/resource/separator"
 
@@ -33,14 +34,11 @@ module Perron
     alias_method :to_param, :slug
 
     def content
-      return Perron::Resource::Separator.new(raw_content).content unless processable?
+      page_content = Perron::Resource::Separator.new(raw_content).content
 
-      ::ApplicationController
-        .renderer
-        .render(
-          inline: Perron::Resource::Separator.new(raw_content).content,
-          assigns: {resource: self}
-        )
+      return page_content unless erb_processing?
+
+      Perron::Resource::Renderer.erb(page_content, {resource: self})
     end
 
     def metadata = Perron::Resource::Separator.new(raw_content).metadata
@@ -55,7 +53,7 @@ module Perron
 
     private
 
-    def processable?
+    def erb_processing?
       @file_path.ends_with?(".erb") || metadata.erb == true
     end
 

--- a/lib/perron/site/resource/renderer.rb
+++ b/lib/perron/site/resource/renderer.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Perron
+  class Resource
+    module Renderer
+      module_function
+
+      def erb(content, assigns = {})
+        ::ApplicationController
+          .renderer
+          .render(
+            inline: content,
+            assigns: assigns
+          )
+      end
+    end
+  end
+end

--- a/test/helpers/perron/erb_helper_test.rb
+++ b/test/helpers/perron/erb_helper_test.rb
@@ -1,0 +1,14 @@
+require "test_helper"
+
+class ErbHelperTest < ActionView::TestCase
+  include Perron::ErbHelper
+
+  setup { @resource = Perron::Resource.new("test/dummy/app/content/pages/about.md") }
+
+  test "erbify processes a string with access to @resource" do
+    content_string = "Page Title: <%= @resource.metadata.title %>"
+    html = erbify(content_string)
+
+    assert_equal "Page Title: About", html.strip
+  end
+end

--- a/test/perron/site/resource/renderer_test.rb
+++ b/test/perron/site/resource/renderer_test.rb
@@ -1,0 +1,30 @@
+require "test_helper"
+
+class Perron::Resource::RendererTest < ActiveSupport::TestCase
+  setup do
+    @resource_path = "test/dummy/app/content/pages/about.md"
+    @resource = Perron::Resource.new(@resource_path)
+  end
+
+  test "renders basic ERB content" do
+    content = "Math works: <%= 5 * 5 %>."
+    rendered = Perron::Resource::Renderer.erb(content)
+
+    assert_equal "Math works: 25.", rendered.strip
+  end
+
+  test "renders ERB with a resource object in assigns" do
+    content = "<h1><%= @resource.metadata.title %></h1>"
+    assigns = { resource: @resource }
+    rendered = Perron::Resource::Renderer.erb(content, assigns)
+
+    assert_equal "<h1>About</h1>", rendered.strip
+  end
+
+  test "handles content with no ERB tags gracefully" do
+    content = "<p>This is just static text.</p>"
+    rendered = Perron::Resource::Renderer.erb(content)
+
+    assert_equal "<p>This is just static text.</p>", rendered.strip
+  end
+end


### PR DESCRIPTION
Added the `erbify` view helper to allow for targeted ERB evaluation within any content file, regardless of its extension or frontmatter settings. This provides more granular control over dynamic content generation.