### PR TITLE
Added `view_unpublished` configuration option

### DIFF
--- a/lib/perron/configuration.rb
+++ b/lib/perron/configuration.rb
@@ -28,6 +28,8 @@ module Perron
       @config.exclude_from_public = %w[assets storage]
       @config.excluded_assets = %w[action_cable actioncable actiontext activestorage rails-ujs trix turbo]
 
+      @config.view_unpublished = Rails.env.development?
+
       @config.default_url_options = {
         host: ENV.fetch("PERRON_HOST", "localhost:3000"),
         protocol: ENV.fetch("PERRON_PROTOCOL", "http"),

--- a/lib/perron/site/resource/publishable.rb
+++ b/lib/perron/site/resource/publishable.rb
@@ -7,7 +7,7 @@ module Perron
 
       included do
         def published?
-          return true if Rails.env.development?
+          return true if Perron.configuration.view_unpublished
 
           return false if metadata.draft == true
           return false if metadata.published == false


### PR DESCRIPTION
```
Perron.configure do |config|
  # …
  config.view_unpublished = false
end
```

Defaults to `Rails.env.development?`; all unpublished/scheduled resources visible in development.