### PR TITLE
Move `assets` from `public` on `rails perron:build`

### DIFF
--- a/lib/perron/site/builder/assets.rb
+++ b/lib/perron/site/builder/assets.rb
@@ -29,7 +29,8 @@ module Perron
           end
 
           FileUtils.mkdir_p(destination)
-          FileUtils.cp_r(Dir.glob("#{source}/*"), destination)
+          FileUtils.move(Dir.glob("#{source}/*"), destination, force: true)
+          FileUtils.remove_dir(source)
 
           puts "   Copied assets to `#{destination.relative_path_from(Rails.root)}`"
 


### PR DESCRIPTION
Previously, on `rails perron:build`, it would copy (`cp_r`) the folder leaving it behind in _public_. When the command was run locally, the assets from _public/assets_ would have precedence over the ones from _app_, leaving a confusing experience. 