### PR TITLE
Logic for nested routes support

### DIFF
--- a/lib/perron/site/builder/paths.rb
+++ b/lib/perron/site/builder/paths.rb
@@ -18,6 +18,10 @@ module Perron
               next if skip? root
 
               @paths << (root ? routes.root_path : routes.public_send(show_path, resource))
+
+              (resource.class.try(:nested_routes) || []).each do |nested|
+                @paths << routes.polymorphic_path([resource, nested])
+              end
             end
           end
         end


### PR DESCRIPTION
This logic assumes the parent resource has a `nested_routes` class method. For example:
```ruby
resources :resources, module: :content, only: %w[show] do
  resource :template, path: "template.rb", module: :resources, only: %w[show]
end
```

Then the class:
```ruby
class Content::Resource < Perron::Resource
  def self.nested_routes = [:template]
end
```

Where `:template` matches `resource :template`.