### PR TITLE
Make erbify block actually work

### DIFF
--- a/lib/perron/resource.rb
+++ b/lib/perron/resource.rb
@@ -48,9 +48,9 @@ module Perron
     def content
       page_content = Perron::Resource::Separator.new(raw_content).content
 
-      return page_content unless erb_processing?
+      return Perron::Resource::Renderer.erb(page_content, resource: self) if erb_processing?
 
-      Perron::Resource::Renderer.erb(page_content, {resource: self})
+      render_inline_erb using: page_content
     end
 
     def to_partial_path
@@ -77,6 +77,12 @@ module Perron
       Digest::SHA1.hexdigest(
         @file_path.delete_prefix(Perron.configuration.input.to_s).parameterize
       ).first(ID_LENGTH)
+    end
+
+    def render_inline_erb(using:)
+      using.gsub(/<%=\s*erbify\s+do\s*%>(.*?)<%\s*end\s*%>/m) do
+        Perron::Resource::Renderer.erb(Regexp.last_match(1).strip_heredoc, resource: self)
+      end
     end
 
     def erb_processing?

--- a/test/dummy/app/content/posts/2025-10-01-inline-erb-post.md
+++ b/test/dummy/app/content/posts/2025-10-01-inline-erb-post.md
@@ -1,0 +1,13 @@
+---
+title: Inline ERB post
+author: Rails Designer
+---
+
+This is a regular paragraph in the post. It should not be processed by ERB.
+
+Here is a special block that should be erbified:
+<%= erbify do %>
+  The slug for this resource is: <%= @resource.slug %> and is it authored by <%= @resource.metadata.author %>
+<% end %>
+
+And one more paragraph for good measure.

--- a/test/perron/resource_test.rb
+++ b/test/perron/resource_test.rb
@@ -4,8 +4,10 @@ class Perron::Site::ResourceTest < ActiveSupport::TestCase
   setup do
     @page_path = "test/dummy/app/content/pages/about.md"
     @post_path = "test/dummy/app/content/posts/2023-05-15-sample-post.md"
+    @inline_erb_post_path = "test/dummy/app/content/posts/2025-10-01-inline-erb-post.md"
     @page = Content::Page.new(@page_path)
     @post = Content::Post.new(@post_path)
+    @inline_erb_post = Content::Post.new(@inline_erb_post_path) # <-- Addition
   end
 
   test "initialization sets file_path" do
@@ -37,6 +39,16 @@ class Perron::Site::ResourceTest < ActiveSupport::TestCase
 
   test "#content returns processed content" do
     assert @post.content
+  end
+
+  test "#content renders inline ERB blocks using erbify helper" do
+    content = @inline_erb_post.content
+
+    assert_match "The slug for this resource is: inline-erb-post", content
+    assert_no_match(/<%= erbify do %>/, content)
+
+    assert_match "This is a regular paragraph", content
+    assert_match "And one more paragraph for good measure", content
   end
 
   test "#metadata returns metadata hash" do

--- a/test/perron/site/builder/feeds/json_test.rb
+++ b/test/perron/site/builder/feeds/json_test.rb
@@ -17,10 +17,10 @@ class Perron::Site::Builder::Feeds::JsonTest < ActiveSupport::TestCase
       assert_equal "Dummy App", json["title"]
       assert_nil json["description"]
       assert_equal "http://localhost:3000/", json["home_page_url"]
-      assert_equal 2, json["items"].count, "Should include 2 posts (one is excluded by frontmatter)"
+      assert_equal 3, json["items"].count, "Should include 3 posts (one is excluded by frontmatter)"
 
       titles = json["items"].map { it["title"] }
-      assert_equal ["Another Sample Post", "Sample Post"], titles, "Posts should be sorted by date descending"
+      assert_equal ["Inline ERB post", "Another Sample Post", "Sample Post"], titles, "Posts should be sorted by date descending"
     end
   end
 
@@ -29,7 +29,7 @@ class Perron::Site::Builder::Feeds::JsonTest < ActiveSupport::TestCase
       json = JSON.parse(@builder.generate)
 
       assert_equal 1, json["items"].count
-      assert_equal "Another Sample Post", json["items"].first["title"]
+      assert_equal "Inline ERB post", json["items"].first["title"]
     end
   end
 

--- a/test/perron/site/builder/feeds/rss_test.rb
+++ b/test/perron/site/builder/feeds/rss_test.rb
@@ -16,10 +16,10 @@ class Perron::Site::Builder::Feeds::RssTest < ActiveSupport::TestCase
       assert_equal "Dummy App", rss.at_xpath("//channel/title").text
       assert_equal "", rss.at_xpath("//channel/description").text
       assert_equal "http://localhost:3000/", rss.at_xpath("//channel/link").text
-      assert_equal 2, rss.xpath("//item").count, "Should include 2 posts (one is excluded by frontmatter)"
+      assert_equal 3, rss.xpath("//item").count, "Should include 2 posts (one is excluded by frontmatter)"
 
       titles = rss.xpath("//item/title").map(&:text)
-      assert_equal ["Another Sample Post", "Sample Post"], titles, "Posts should be sorted by date descending"
+      assert_equal ["Inline ERB post", "Another Sample Post", "Sample Post"], titles, "Posts should be sorted by date descending"
     end
   end
 
@@ -28,7 +28,7 @@ class Perron::Site::Builder::Feeds::RssTest < ActiveSupport::TestCase
       rss = Nokogiri::XML(@builder.generate).remove_namespaces!
 
       assert_equal 1, rss.xpath("//item").count
-      assert_equal "Another Sample Post", rss.at_xpath("//item/title").text
+      assert_equal "Inline ERB post", rss.at_xpath("//item/title").text
     end
   end
 


### PR DESCRIPTION
Erbifying in a standard `.md` file now does actually work:
```markdown
---
title: Features
features:
  - Rails based
  - SEO friendly
  - Markdown first
  - ERB support
---

Check out our amazing features:

<%= erbify do %>
  <ul>
    <% @resource.metadata.features.each do |feature| %>
      <li>
        <%= feature %>
      </li>
    <% end %>
  </ul>
<% end %>
```