### PR TITLE
Added `estimated_reading_time` method to Perron::Resource

### DIFF
--- a/lib/perron/resource.rb
+++ b/lib/perron/resource.rb
@@ -5,6 +5,7 @@ require "perron/resource/core"
 require "perron/resource/class_methods"
 require "perron/resource/metadata"
 require "perron/resource/publishable"
+require "perron/resource/reading_time"
 require "perron/resource/related"
 require "perron/resource/renderer"
 require "perron/resource/slug"
@@ -20,6 +21,7 @@ module Perron
     include Perron::Resource::Configuration
     include Perron::Resource::Core
     include Perron::Resource::ClassMethods
+    include Perron::Resource::ReadingTime
     include Perron::Resource::Publishable
     include Perron::Resource::TableOfContent
 

--- a/lib/perron/resource/reading_time.rb
+++ b/lib/perron/resource/reading_time.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Perron
+  class Resource
+    module ReadingTime
+      extend ActiveSupport::Concern
+
+      def estimated_reading_time(wpm: DEFAULT_WORDS_PER_MINUTE, format: DEFAULT_FORMAT)
+        word_count = content.scan(/\b[a-zA-Z]+\b/).size
+        total_minutes = [(word_count.to_f / wpm).ceil, 1].max
+
+        hours = total_minutes / 60
+        minutes = total_minutes % 60
+        seconds = ((word_count.to_f / wpm) * 60).to_i % 60
+
+        return total_minutes if format.blank?
+
+        format % {
+          minutes: minutes,
+          total_minutes: total_minutes,
+          hours: hours,
+          seconds: seconds,
+          min: minutes,
+          h: hours,
+          s: seconds
+        }
+      end
+      alias_method :reading_time, :estimated_reading_time
+
+      private
+
+      DEFAULT_WORDS_PER_MINUTE = 200
+      DEFAULT_FORMAT = "%{minutes} min read"
+    end
+  end
+end

--- a/test/dummy/app/content/posts/2023-05-15-sample-post.md
+++ b/test/dummy/app/content/posts/2023-05-15-sample-post.md
@@ -4,4 +4,12 @@ description: Describing sample post
 image: https://example.com/images/sample.jpg
 ---
 
-Content goes here…
+Labore qui mollit commodo id nulla qui exercitation nulla reprehenderit nulla excepteur aute eu sint. Minim sit aute et ad ut esse aute sunt magna voluptate duis tempor. Commodo commodo qui amet ullamco Lorem ex cillum ea occaecat deserunt elit amet consequat nulla Lorem. Reprehenderit id aute dolor minim aliquip officia et reprehenderit nisi. Aute labore ex veniam enim enim duis sint elit proident aute sunt consectetur ut aliqua. Laboris elit exercitation veniam non commodo magna sunt in sunt id.
+
+Velit est sunt tempor aute do ad tempor labore ut mollit. Consectetur mollit aute tempor aliqua sint cupidatat magna ullamco ullamco ut nulla sint pariatur id. Cupidatat irure eiusmod do nulla sit culpa veniam. Proident voluptate ex incididunt mollit fugiat adipisicing nostrud irure adipisicing aliquip irure duis.
+
+Aute nulla ex commodo tempor dolore reprehenderit laboris deserunt non ad veniam qui. Laboris quis culpa sint occaecat dolor tempor magna duis in. Aute sit enim ipsum velit cupidatat nisi irure laboris labore culpa aliqua ullamco non velit. Labore eu pariatur reprehenderit proident quis proident est aliquip et anim ut. Commodo sit consequat dolore reprehenderit consectetur. Sint veniam commodo elit adipisicing aliqua magna consectetur proident anim laborum fugiat occaecat. Magna in qui laboris et deserunt veniam voluptate mollit non culpa id excepteur dolore elit.
+
+Qui magna proident veniam tempor. Nisi commodo duis ut ad ea ullamco consectetur et esse deserunt deserunt cupidatat. Irure et minim aute. Sunt proident est mollit veniam laborum voluptate incididunt.
+
+Et nisi et nulla ad id non laborum duis. Aliqua nisi tempor culpa aliquip nostrud velit Lorem nisi. Incididunt laborum aute cillum quis nulla id quis et mollit esse. Dolore Lorem sint reprehenderit nisi do ut laborum et magna nisi. Nulla non eiusmod commodo anim sint eiusmod officia labore sit elit incididunt magna eu eu. Adipisicing est aute non dolore do aute amet. Id laborum fugiat aliqua laboris eiusmod sit occaecat qui esse nostrud.

--- a/test/perron/resource/resource_publishable_test.rb
+++ b/test/perron/resource/resource_publishable_test.rb
@@ -7,8 +7,8 @@ class Perron::Site::Resource::PublishableTest < ActiveSupport::TestCase
     @page_path = "test/dummy/app/content/pages/about.md"
     @post_path = "test/dummy/app/content/posts/2023-05-15-sample-post.md"
 
-    @page_resource = Perron::Resource.new(@page_path)
-    @post_resource = Perron::Resource.new(@post_path)
+    @page_resource = Content::Page.new(@page_path)
+    @post_resource = Content::Post.new(@post_path)
   end
 
   teardown { travel_back }

--- a/test/perron/resource/resource_reading_time_test.rb
+++ b/test/perron/resource/resource_reading_time_test.rb
@@ -1,0 +1,60 @@
+require "test_helper"
+
+class Perron::Resource::ReadingTimeTest < ActiveSupport::TestCase
+  setup { @post_resource = Content::Post.new("test/dummy/app/content/posts/2023-05-15-sample-post.md") }
+
+  test "#estimated_reading_time returns total minutes without format" do
+    result = @post_resource.estimated_reading_time(format: nil)
+
+    assert_kind_of Integer, result
+    assert_operator result, :>=, 1
+  end
+
+  test "#estimated_reading_time returns formatted string with default format" do
+    result = @post_resource.estimated_reading_time
+
+    assert_kind_of String, result
+    assert_match(/\d+ min read/, result)
+  end
+
+  test "#estimated_reading_time accepts custom wpm" do
+    slow_read = @post_resource.estimated_reading_time(wpm: 100, format: nil)
+    fast_read = @post_resource.estimated_reading_time(wpm: 300, format: nil)
+
+    assert_operator slow_read, :>, fast_read
+  end
+
+  test "#estimated_reading_time accepts custom format with minutes" do
+    result = @post_resource.estimated_reading_time(format: "%{minutes} minutes")
+
+    assert_match(/\d+ minutes/, result)
+  end
+
+  test "#estimated_reading_time accepts custom format with hours" do
+    result = @post_resource.estimated_reading_time(format: "%{hours}h %{minutes}m")
+
+    assert_match(/\d+h \d+m/, result)
+  end
+
+  test "#estimated_reading_time accepts custom format with seconds" do
+    result = @post_resource.estimated_reading_time(format: "%{seconds}s")
+
+    assert_match(/\d+s/, result)
+  end
+
+  test "#estimated_reading_time supports short-form aliases" do
+    result = @post_resource.estimated_reading_time(format: "%{h}:%{min}:%{s}")
+
+    assert_match(/\d+:\d+:\d+/, result)
+  end
+
+  test "#estimated_reading_time has minimum of 1 minute" do
+    result = @post_resource.estimated_reading_time(wpm: 999999, format: nil)
+
+    assert_equal 1, result
+  end
+
+  test "#reading_time is an alias for estimated_reading_time" do
+    assert_equal @post_resource.estimated_reading_time, @post_resource.reading_time
+  end
+end


### PR DESCRIPTION
This method can return the (formatted) estimated reading time.

```
@resource.estimated_reading_time
@resource.estimated_reading_time format: "about %{minutes} mins of reading"
@resource.estimated_reading_time format: nil
```

Aliased to `reading_time`.