### PR TITLE
Added resource associations: belongs_to/has_many

### DIFF
--- a/lib/perron/resource.rb
+++ b/lib/perron/resource.rb
@@ -3,6 +3,7 @@
 require "perron/resource/configuration"
 require "perron/resource/core"
 require "perron/resource/class_methods"
+require "perron/resource/associations"
 require "perron/resource/metadata"
 require "perron/resource/publishable"
 require "perron/resource/reading_time"
@@ -21,6 +22,7 @@ module Perron
     include Perron::Resource::Configuration
     include Perron::Resource::Core
     include Perron::Resource::ClassMethods
+    include Perron::Resource::Associations
     include Perron::Resource::ReadingTime
     include Perron::Resource::Publishable
     include Perron::Resource::TableOfContent

--- a/lib/perron/resource/associations.rb
+++ b/lib/perron/resource/associations.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+module Perron
+  class Resource
+    module Associations
+      extend ActiveSupport::Concern
+
+      class_methods do
+        def belongs_to(association_name, **options)
+          define_method(association_name) do
+            cache_belongs_to_association(association_name) do
+              associated_class = association_class_for(association_name, **options)
+              foreign_key = foreign_key_for(association_name, **options)
+              identifier = metadata[foreign_key]
+
+              identifier ? associated_class.find(identifier) : nil
+            end
+          end
+        end
+
+        def has_many(association_name, **options)
+          define_method(association_name) do
+            cache_has_many_association(association_name) do
+              associated_class = association_class_for(association_name, singularize: true, **options)
+              foreign_key = foreign_key_for(inverse_association_name, **options)
+              primary_key_method = options.fetch(:primary_key, :slug)
+              lookup_value = public_send(primary_key_method)
+
+              associated_class.all.select { |record| record.metadata[foreign_key] == lookup_value }
+            end
+          end
+        end
+      end
+
+      private
+
+      def cache_belongs_to_association(name)
+        @belongs_to_cache ||= {}
+        return @belongs_to_cache[name] if @belongs_to_cache.key?(name)
+
+        @belongs_to_cache[name] = yield
+      end
+
+      def cache_has_many_association(name)
+        @has_many_cache ||= {}
+        return @has_many_cache[name] if @has_many_cache.key?(name)
+
+        @has_many_cache[name] = yield
+      end
+
+      def association_class_for(association_name, singularize: false, **options)
+        class_name = options[:class_name] || begin
+          name = association_name.to_s
+          name = name.singularize if singularize
+
+          "Content::#{name.classify}"
+        end
+
+        class_name.constantize
+      end
+
+      def foreign_key_for(base_name, **options)
+        (options[:foreign_key] || "#{base_name}_id").to_s
+      end
+
+      def inverse_association_name = self.class.name.demodulize.underscore
+    end
+  end
+end

--- a/test/dummy/app/content/authors/not-rails-designer.md
+++ b/test/dummy/app/content/authors/not-rails-designer.md
@@ -1,0 +1,5 @@
+---
+name: Not Rails Designer
+---
+
+Hello? Wodis?

--- a/test/dummy/app/content/authors/rails-designer.md
+++ b/test/dummy/app/content/authors/rails-designer.md
@@ -1,0 +1,9 @@
+---
+name: Rails Designer
+bio: I run this site!
+email: support@railsdesigner.com
+website: https://railsdesigner.com/
+avatar: /images/authors/rails-designer.jpg
+---
+
+Where Rails developers come to build beautiful Rails apps. UI component library, Rails UI consultancy, and SaaS expertise & development.

--- a/test/dummy/app/content/posts/2023-05-15-sample-post.md
+++ b/test/dummy/app/content/posts/2023-05-15-sample-post.md
@@ -2,6 +2,7 @@
 title: Sample Post
 description: Describing sample post
 image: https://example.com/images/sample.jpg
+author_id: rails-designer
 ---
 
 Labore qui mollit commodo id nulla qui exercitation nulla reprehenderit nulla excepteur aute eu sint. Minim sit aute et ad ut esse aute sunt magna voluptate duis tempor. Commodo commodo qui amet ullamco Lorem ex cillum ea occaecat deserunt elit amet consequat nulla Lorem. Reprehenderit id aute dolor minim aliquip officia et reprehenderit nisi. Aute labore ex veniam enim enim duis sint elit proident aute sunt consectetur ut aliqua. Laboris elit exercitation veniam non commodo magna sunt in sunt id.

--- a/test/dummy/app/models/content/author.rb
+++ b/test/dummy/app/models/content/author.rb
@@ -1,0 +1,3 @@
+class Content::Author < Perron::Resource
+  has_many :posts
+end

--- a/test/dummy/app/models/content/post.rb
+++ b/test/dummy/app/models/content/post.rb
@@ -1,4 +1,6 @@
 class Content::Post < Perron::Resource
+  belongs_to :author
+
   configure do |config|
     config.sitemap.enabled = false
 

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  resources :authors, module: :content, only: %w[show]
   resources :posts, path: "blog", module: :content, only: %w[index show]
   resources :products, path: "/", module: :content, only: %w[index show]
   resources :pages, path: "/", module: :content, only: %w[show]

--- a/test/perron/resource/associations_test.rb
+++ b/test/perron/resource/associations_test.rb
@@ -1,0 +1,59 @@
+require "test_helper"
+
+class Perron::Resource::AssociationsTest < ActiveSupport::TestCase
+  setup do
+    @post_path = "test/dummy/app/content/posts/2023-05-15-sample-post.md"
+    @author_path = "test/dummy/app/content/authors/rails-designer.md"
+
+    @post = Content::Post.new(@post_path)
+    @author = Content::Author.new(@author_path)
+  end
+
+  test "belongs_to returns associated resource" do
+    assert_kind_of Content::Author, @post.author
+    assert_equal "rails-designer", @post.author.slug
+  end
+
+  test "belongs_to returns nil when foreign key is missing" do
+    post_without_author_path = "test/dummy/app/content/posts/2025-10-01-inline-erb-post.md"
+    post_without_author = Content::Post.new(post_without_author_path)
+
+    assert_nil post_without_author.author
+  end
+
+  test "belongs_to caches the association" do
+    first_call = @post.author
+    second_call = @post.author
+
+    assert_same first_call, second_call
+  end
+
+  test "has_many returns collection of associated resources" do
+    posts = @author.posts
+
+    assert_kind_of Array, posts
+    assert posts.all? { it.is_a?(Content::Post) }
+    assert posts.any? { it.metadata["author_id"] == @author.slug }
+  end
+
+  test "has_many returns empty array when no associations exist" do
+    author_without_posts_path = "test/dummy/app/content/authors/not-rails-designer.md"
+    author_without_posts = Content::Author.new(author_without_posts_path)
+
+    assert_equal [], author_without_posts.posts
+  end
+
+  test "has_many caches the association" do
+    first_call = @author.posts
+    second_call = @author.posts
+
+    assert_same first_call, second_call
+  end
+
+  test "associations work bidirectionally" do
+    author = @post.author
+    author_post_ids = author.posts.map { it.metadata["author_id"] }
+
+    assert author_post_ids.all? { it == author.slug }
+  end
+end


### PR DESCRIPTION
Define a `has_many` association to retrieve all resources that belong to the current resource:
```ruby
# app/models/content/author.rb
class Content::Author < Perron::Resource
  has_many :posts
end

author = Content::Author.find("rails-designer")
author.posts # => Array of Content::Post instances where author_id matches
```

Define a `belongs_to` association when a resource references another resource:
```ruby
# app/models/content/post.rb
class Content::Post < Perron::Resource
  belongs_to :author
end
```

In your content's frontmatter, add the foreign key with `_id` suffix:
```markdown
<!-- app/content/posts/my-first-post.md -->
---
title: My First Post
author_id: rails-designer
---

Post content here…
```

```bash
post = Content::Post.find("my-first-post")
post.author # => Content::Author instance
```