### PR TITLE
Ref for feed

### DIFF
--- a/lib/perron/site/builder/feeds/json.rb
+++ b/lib/perron/site/builder/feeds/json.rb
@@ -25,7 +25,7 @@ module Perron
                 items: resources.map do |resource|
                   {
                     id: resource.id,
-                    url: url.polymorphic_url(resource),
+                    url: url.polymorphic_url(resource, ref: feed_configuration.ref).delete_suffix("?ref="),
                     date_published: resource.published_at&.iso8601,
                     title: resource.metadata.title,
                     content_html: Perron::Markdown.render(resource.content)

--- a/lib/perron/site/builder/feeds/rss.rb
+++ b/lib/perron/site/builder/feeds/rss.rb
@@ -27,7 +27,7 @@ module Perron
                     resources.each do |resource|
                       xml.item do
                         xml.guid resource.id
-                        xml.link url.polymorphic_url(resource), isPermaLink: true
+                        xml.link url.polymorphic_url(resource, ref: feed_configuration.ref).delete_suffix("?ref="), isPermaLink: true
                         xml.pubDate(resource.published_at&.rfc822)
                         xml.title resource.metadata.title
                         xml.description { xml.cdata(Perron::Markdown.render(resource.content)) }

--- a/test/perron/site/builder/feeds/json_test.rb
+++ b/test/perron/site/builder/feeds/json_test.rb
@@ -24,15 +24,6 @@ class Perron::Site::Builder::Feeds::JsonTest < ActiveSupport::TestCase
     end
   end
 
-  test "respects max_items configuration" do
-    @collection.configuration.feeds.json.stub(:max_items, 1) do
-      json = JSON.parse(@builder.generate)
-
-      assert_equal 1, json["items"].count
-      assert_equal "Inline ERB post", json["items"].first["title"]
-    end
-  end
-
   test "configured feed name and description" do
     @collection.configuration.feeds.json.stub(:title, "Custom JSON title") do
       json = JSON.parse(@builder.generate)
@@ -44,6 +35,27 @@ class Perron::Site::Builder::Feeds::JsonTest < ActiveSupport::TestCase
       json = JSON.parse(@builder.generate)
 
       assert_equal "Custom JSON description", json["description"]
+    end
+  end
+
+  test "respects max_items configuration" do
+    @collection.configuration.feeds.json.stub(:max_items, 1) do
+      json = JSON.parse(@builder.generate)
+
+      assert_equal 1, json["items"].count
+      assert_equal "Inline ERB post", json["items"].first["title"]
+      assert_equal "http://localhost:3000/blog/inline-erb-post/", json["items"].first["url"]
+    end
+  end
+
+  test "sets a `ref` param to the link" do
+    @collection.configuration.feeds.json.stub(:ref, "perron.railsdesigner.com") do
+      @collection.configuration.feeds.json.stub(:max_items, 1) do
+        json = JSON.parse(@builder.generate)
+
+        assert_equal 1, json["items"].count
+        assert_equal "http://localhost:3000/blog/inline-erb-post/?ref=perron.railsdesigner.com", json["items"].first["url"]
+      end
     end
   end
 end

--- a/test/perron/site/builder/feeds/rss_test.rb
+++ b/test/perron/site/builder/feeds/rss_test.rb
@@ -45,4 +45,24 @@ class Perron::Site::Builder::Feeds::RssTest < ActiveSupport::TestCase
       assert_equal "Custom RSS description", rss.at_xpath("//channel/description").text
     end
   end
+
+  test "uses polymorphic links for items" do
+    @collection.configuration.feeds.rss.stub(:max_items, 1) do
+      rss = Nokogiri::XML(@builder.generate).remove_namespaces!
+
+      assert_equal 1, rss.xpath("//item").count
+      assert_equal "http://localhost:3000/blog/inline-erb-post/", rss.at_xpath("//item/link").text
+    end
+  end
+
+  test "sets a `ref` param to the link" do
+    @collection.configuration.feeds.rss.stub(:ref, "perron.railsdesigner.com") do
+      @collection.configuration.feeds.rss.stub(:max_items, 1) do
+        rss = Nokogiri::XML(@builder.generate).remove_namespaces!
+
+        assert_equal 1, rss.xpath("//item").count
+        assert_equal "http://localhost:3000/blog/inline-erb-post/?ref=perron.railsdesigner.com", rss.at_xpath("//item/link").text
+      end
+    end
+  end
 end


### PR DESCRIPTION
Allows adding a ref query parameter to feed item links for traffic tracking.
Configure with `config.feeds.rss.ref = "source"` to append `?ref=source` to all item URLs.