### PR TITLE
Added `preview?` alias for `previewable?`

### DIFF
--- a/lib/perron/resource/previewable.rb
+++ b/lib/perron/resource/previewable.rb
@@ -9,6 +9,7 @@ module Perron
         def previewable?
           frontmatter.preview.present? && (draft? || scheduled?)
         end
+        alias_method :preview?, :previewable?
 
         def preview_token
           return nil unless previewable?

--- a/test/models/perron/resource/previewable_test.rb
+++ b/test/models/perron/resource/previewable_test.rb
@@ -23,6 +23,10 @@ class Perron::Resource::PreviewableTest < ActiveSupport::TestCase
     assert @preview_feature.previewable?
   end
 
+  test "#preview? alias of #previewable?" do
+    assert @preview_feature.preview?
+  end
+
   test "#preview_token returns nil when not previewable" do
     assert_nil @public_feature.preview_token
   end


### PR DESCRIPTION
Will be suggesting `preview?` in docs instead of `previewable?` (but keep it for semi-internal). 

Related to https://github.com/Rails-Designer/perron/pull/75