### PR TITLE
Add OutputServer middleware to serve /output/ folder

### DIFF
--- a/lib/perron/engine.rb
+++ b/lib/perron/engine.rb
@@ -1,15 +1,22 @@
 # frozen_string_literal: true
 
+require "perron/output_server"
+
 module Perron
   class Engine < Rails::Engine
     initializer "perron.default_url_options" do |app|
       app.config.action_controller.default_url_options = Perron.configuration.default_url_options
     end
 
+    initializer "perron.output_server" do |app|
+      app.middleware.use Perron::OutputServer
+    end
+
     rake_tasks do
       load File.expand_path("../tasks/build.rake", __FILE__)
-      load File.expand_path("../tasks/validate.rake", __FILE__)
+      load File.expand_path("../tasks/clobber.rake", __FILE__)
       load File.expand_path("../tasks/sync_sources.rake", __FILE__)
+      load File.expand_path("../tasks/validate.rake", __FILE__)
     end
   end
 end

--- a/lib/perron/output_server.rb
+++ b/lib/perron/output_server.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Perron
+  class OutputServer
+    def initialize(app)
+      @app = app
+    end
+
+    def call(environment)
+      return @app.call(environment) if disabled?
+
+      static_file(environment).then do |file|
+        file ? serve(file) : @app.call(environment)
+      end
+    end
+
+    private
+
+    def disabled? = !enabled?
+
+    def static_file(environment)
+      request_path = Rack::Request.new(environment).path_info
+      file_path = File.join(output_path, request_path, "index.html")
+
+      File.file?(file_path) ? file_path : nil
+    end
+
+    def serve(file_path)
+      content = File.read(file_path)
+
+      [
+        200,
+
+        {
+          "Content-Type" => "text/html; charset=utf-8",
+          "Content-Length" => content.bytesize.to_s
+        },
+
+        [content]
+      ]
+    end
+
+    def enabled? = Dir.exist?(output_path)
+
+    def output_path
+      @output_path ||= Rails.root.join(Perron.configuration.output)
+    end
+  end
+end

--- a/lib/perron/tasks/clobber.rake
+++ b/lib/perron/tasks/clobber.rake
@@ -1,0 +1,12 @@
+namespace :perron do
+  desc "Remove compiled static output"
+  task clobber: :environment do
+    output_path = Rails.root.join(Perron.configuration.output)
+
+    if Dir.exist?(output_path)
+      FileUtils.rm_rf(output_path)
+
+      puts "Removed #{output_path}"
+    end
+  end
+end


### PR DESCRIPTION
Closes https://github.com/Rails-Designer/perron/issues/90

Adds middleware that serves static files from the output directory before passing requests to Rails routing. Automatically enabled when output directory exists.

Previously you had to run another server to inspect the generated static files. I think this is an improvement. It could be considered unexpected behaviour (“why are my changes not showing?!”), but since `perron:build` needs to run explicitly I think this won't be a big problem. Alternatively could make it opt-in through configuration.

Also adds `bin/rails perron:clobber` task to remove generated output. 