### PR TITLE
Add `--data` flag to content generator for data sources

### DIFF
--- a/lib/generators/rails/content/USAGE
+++ b/lib/generators/rails/content/USAGE
@@ -17,6 +17,13 @@ Examples:
 
     And adds: resources :posts, module: :content, only: %w[index show]
 
+    Generate content scaffold with data sources:
+        rails generate content Product --data countries products
+        rails generate content Product --data countries.json products.yml
+
+    This will additionally create data source files in app/content/products/
+    and add sources/template_source class methods to the model.
+
     Create new content file from template:
         rails generate content Post --new
         rails generate content Post --new "My First Post"
@@ -38,4 +45,5 @@ Arguments:
 
 Options:
     --new [TITLE]: Create new content file instead of scaffold
+    --data [source1(.ext) source2(.ext)]: Create data source files (default extension: .yml)
     --force-plural: Use plural form for model name and class

--- a/lib/generators/rails/content/content_generator.rb
+++ b/lib/generators/rails/content/content_generator.rb
@@ -7,9 +7,12 @@ module Rails
     class ContentGenerator < Rails::Generators::NamedBase
       source_root File.expand_path("templates", __dir__)
 
-      class_option :force_plural, type: :boolean, default: false, desc: "Forces the use of a plural model name and class"
+      class_option :force_plural, type: :boolean, default: false,
+        desc: "Forces the use of a plural model name and class"
       class_option :new, type: :string, default: nil, banner: "TITLE",
         desc: "Create a new content file from template instead of generating scaffold"
+      class_option :data, type: :array, default: [], banner: "source1(.ext) source2(.ext)",
+        desc: "Specify data sources with optional extensions (defaults to .yml)"
 
       argument :actions, type: :array, default: %w[index show], banner: "actions", desc: "Specify which actions to generate (index/show)"
 
@@ -67,6 +70,17 @@ module Rails
         template "root.erb.tt", File.join(content_directory, "root.erb")
       end
 
+      def create_data_sources
+        return if @content_mode
+        return if options[:data].empty?
+
+        options[:data].each do |source|
+          name, extension = source.split(".", 2)
+
+          create_file File.join(content_directory, "#{name}.#{extension || "yml"}"), ""
+        end
+      end
+
       def add_content_route
         return if @content_mode
 
@@ -121,6 +135,12 @@ module Rails
           end
         end
       end
+
+      def data_sources
+        options[:data].map { it.split(".").first }
+      end
+
+      def data_sources? = !options[:data].empty?
     end
   end
 end

--- a/lib/generators/rails/content/templates/model.rb.tt
+++ b/lib/generators/rails/content/templates/model.rb.tt
@@ -1,2 +1,13 @@
 class Content::<%= class_name %> < Perron::Resource
+<% if data_sources? -%>
+
+  sources <%= data_sources.map { ":#{it}" }.join(", ") %>
+
+  def self.source_template(sources)
+    <<~TEMPLATE
+    ---
+    ---
+    TEMPLATE
+  end
+<% end -%>
 end

--- a/test/generators/perron/content_generator_test.rb
+++ b/test/generators/perron/content_generator_test.rb
@@ -53,6 +53,34 @@ class ContentGeneratorTest < Rails::Generators::TestCase
     assert_no_file "app/controllers/content/posts_controller.rb"
   end
 
+  test "--data flag creates data source files with default yml extension" do
+    run_generator %w[product --data countries products]
+
+    assert_file "app/content/products/countries.yml"
+    assert_file "app/content/products/products.yml"
+
+    assert_file "app/models/content/product.rb", /sources :countries, :products/
+    assert_file "app/models/content/product.rb", /def self\.source_template\(sources\)/
+  end
+
+  test "--data flag creates data source files with custom extensions" do
+    run_generator %w[product --data countries.json products.yml]
+
+    assert_file "app/content/products/countries.json"
+    assert_file "app/content/products/products.yml"
+
+    assert_file "app/models/content/product.rb", /sources :countries, :products/
+  end
+
+  test "--data flag with mixed extensions" do
+    run_generator %w[product --data countries.json products]
+
+    assert_file "app/content/products/countries.json"
+    assert_file "app/content/products/products.yml"
+
+    assert_file "app/models/content/product.rb", /sources :countries, :products/
+  end
+
   private
 
   def create_routes_file


### PR DESCRIPTION
Closes https://github.com/Rails-Designer/perron/issues/82

Generates data source files and adds `sources …` / `source_template(sources)` class methods to the model. Extensions default to .yml if none specified.

Related to https://perron.railsdesigner.com/docs/programmatic-content-creation/