### PR TITLE
Updated bin/release script

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -3,17 +3,32 @@
 VERSION=$1
 
 if [ -z "$VERSION" ]; then
-  echo "Error: The version number is required."
-  echo "Usage: $0 <version-number>"
+  echo "Error: Version number or bump type is required"
+  echo "  Usage: $0 <major|minor|patch|version-number>"
+
   exit 1
 fi
 
+if [[ "$VERSION" =~ ^(major|minor|patch)$ ]]; then
+  CURRENT=$(grep -o '"[^"]*"' ./lib/perron/version.rb | tr -d '"')
+  IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT"
+
+  case $VERSION in
+    major) VERSION="$((MAJOR + 1)).0.0" ;;
+    minor) VERSION="$MAJOR.$((MINOR + 1)).0" ;;
+    patch) VERSION="$MAJOR.$MINOR.$((PATCH + 1))" ;;
+  esac
+fi
+
 printf "module Perron\n  VERSION = \"$VERSION\"\nend\n" > ./lib/perron/version.rb
+
 bundle
+
 git add Gemfile.lock lib/perron/version.rb
 git commit -m "Bump version for $VERSION"
 git push
 git tag v$VERSION
 git push --tags
-gem build perron.gemspec
-gem push "perron-$VERSION.gem"
+
+bundle exec rake build
+gem push "pkg/perron-$VERSION.gem"


### PR DESCRIPTION
Allows to pass `{major,minor,patch}` instead of a version number (which I always have to look up). 🦥