### PR TITLE
Suppress view filename annotations for inline ERB renders

### DIFF
--- a/lib/perron/resource/renderer.rb
+++ b/lib/perron/resource/renderer.rb
@@ -5,13 +5,30 @@ module Perron
     module Renderer
       module_function
 
+      # Suppress annotate_rendered_view_with_filenames for inline ERB.
+      # When enabled (typical only in development), Rails wraps output with
+      # <!-- BEGIN/END inline template --> HTML comments. This can interfere
+      # when we "markdownify" the output, resulting in the beginning of the
+      # document being unstyled.
       def erb(content, assigns = {})
-        ::ApplicationController
-          .renderer
-          .render(
-            inline: content,
-            assigns: assigns
-          )
+        suppress_rendered_view_annotations do
+          ::ApplicationController
+            .renderer
+            .render(
+              inline: content,
+              assigns: assigns
+            )
+        end
+      end
+
+      private
+
+      def suppress_rendered_view_annotations(&block)
+        old = ActionView::Base.annotate_rendered_view_with_filenames
+        ActionView::Base.annotate_rendered_view_with_filenames = false
+        block.call
+      ensure
+        ActionView::Base.annotate_rendered_view_with_filenames = old
       end
     end
   end


### PR DESCRIPTION
> [!NOTE]
> This problem is relatively minor, as it typically would only affect rendering during development.
> I also don't really like having to be so specific in how we're disabling a dev-feature... this doesn't "feel" like the right solution.
> Open to ideas on other ways to fix

## Problem

When `config.action_view.annotate_rendered_view_with_filenames = true` (the default in `config/environments/development.rb`), Rails wraps rendered output with HTML comments:

```html
<!-- BEGIN inline template 
-->**This should be bold but renders as a raw string**

# Subsequent Content
* Looks
* Fine 
<!-- END inline template -->
```

When this output is later processed as Markdown (I'm using CommonMarker), the `-->` at the end of the opening comment causes the parser to treat the following content as part of an HTML block rather than Markdown. This leaves the beginning of the document unstyled — bold, links, and other formatting are not rendered.

## Solution

Temporarily disable `ActionView::Base.annotate_rendered_view_with_filenames` around `ApplicationController.renderer.render(inline:)` calls in `Perron::Resource::Renderer.erb`. The original value is restored in an `ensure` block.