### PR TITLE
Default RAILS_ENV to production for perron:build

### DIFF
--- a/lib/perron/tasks/build.rake
+++ b/lib/perron/tasks/build.rake
@@ -1,6 +1,13 @@
 namespace :perron do
+  task :set_production_env do
+    unless ENV["RAILS_ENV"]
+      ENV["RAILS_ENV"] = "production"
+      puts "RAILS_ENV not set, defaulting to production"
+    end
+  end
+
   desc "Generate static HTML files from Perron collections"
-  task build: :environment do
+  task build: [:set_production_env, :environment] do
     Perron::Site.build
   end
 end

--- a/test/perron/tasks/build_rake_test.rb
+++ b/test/perron/tasks/build_rake_test.rb
@@ -1,0 +1,37 @@
+require "test_helper"
+require "rake"
+
+class BuildTest < ActiveSupport::TestCase
+  setup do
+    unless Rake::Task.task_defined?("perron:set_production_env")
+      Rake::Task.define_task("assets:precompile")
+      Rake::Task.define_task(:environment)
+
+      load File.expand_path("../../../lib/perron/tasks/build.rake", __dir__)
+    end
+
+    @original_rails_env = ENV["RAILS_ENV"]
+  end
+
+  teardown do
+    ENV["RAILS_ENV"] = @original_rails_env
+
+    Rake::Task["perron:set_production_env"].reenable
+  end
+
+  test "defaults RAILS_ENV to production when not set" do
+    ENV.delete("RAILS_ENV")
+
+    Rake::Task["perron:set_production_env"].invoke
+
+    assert_equal "production", ENV["RAILS_ENV"]
+  end
+
+  test "does not override RAILS_ENV when already set" do
+    ENV["RAILS_ENV"] = "staging"
+
+    Rake::Task["perron:set_production_env"].invoke
+
+    assert_equal "staging", ENV["RAILS_ENV"]
+  end
+end


### PR DESCRIPTION
## Summary
- The `perron:build` task now defaults `RAILS_ENV` to `production` when not explicitly set, so users can simply run `bin/rails perron:build` instead of `RAILS_ENV=production bin/rails perron:build`
- Prints `RAILS_ENV not set, defaulting to production` when the default is applied
- Users can still override with `RAILS_ENV=staging bin/rails perron:build`

Closes #96