### PR TITLE
Add inline rendering support to Perron::Resource

### DIFF
--- a/lib/perron/resource.rb
+++ b/lib/perron/resource.rb
@@ -68,6 +68,10 @@ module Perron
       render_inline_erb using: page_content
     end
 
+    def inline(layout: "application", **options)
+      {html: content, layout: layout}.merge(options)
+    end
+
     def collection = Collection.new(self.class.model_name.collection)
 
     def related_resources(limit: 5) = Perron::Site::Resource::Related.new(self).find(limit:)

--- a/test/perron/resource_test.rb
+++ b/test/perron/resource_test.rb
@@ -98,4 +98,23 @@ class Perron::Site::ResourceTest < ActiveSupport::TestCase
     assert @invalid_page.errors.any?
     assert_includes @invalid_page.errors.full_messages, "Description can't be blank"
   end
+
+  test "#inline returns hash with html content and default layout" do
+    result = @page.inline
+
+    assert_equal @page.content, result[:html]
+    assert_equal "application", result[:layout]
+  end
+
+  test "#inline accepts a custom layout" do
+    result = @page.inline(layout: "admin")
+
+    assert_equal "admin", result[:layout]
+  end
+
+  test "#inline merges additional options" do
+    result = @page.inline(status: :not_found)
+
+    assert_equal :not_found, result[:status]
+  end
 end


### PR DESCRIPTION
## Summary
- Adds an `inline` method to `Perron::Resource` so controllers can render content without a dedicated view template
- Defaults to the `application` layout, accepts a custom layout and additional options (e.g. `status:`)
- Usage: `render @resource.inline` or `render @resource.inline(layout: "admin", status: :not_found)`

Closes #109