### PR TITLE
I18n/locales exploration

### DIFF
--- a/lib/perron/collection.rb
+++ b/lib/perron/collection.rb
@@ -38,12 +38,18 @@ module Perron
 
     private
 
-    def load_resources(resource_class = "Content::#{name.classify}".safe_constantize)
+    def load_resources(resource_class = "Content::#{name.classify}".safe_constantize, locale: I18n.locale.to_s)
       allowed_extensions = Perron.configuration.allowed_extensions.map { ".#{it}" }.to_set
 
-      Dir.glob("#{@collection_path}/**/*.*")
+      Dir.glob("#{collection_path}/**/*.*")
         .select { allowed_extensions.include?(File.extname(it)) }
         .map { resource_class.new(it) }
+    end
+
+    def collection_path
+      locale_path = "#{@collection_path}/#{I18n.locale.to_s}"
+
+      Dir.exist?(locale_path) ? locale_path : @collection_path
     end
   end
 end


### PR DESCRIPTION
This PR is to explore how to add i18n/locale to Perron. Since Perron is _just Rails_ most of the i18n code can be used. 

But how to structure the content files? Currently leaning towards `app/content/:collection_name/:locale/*/*.*` (another option would be `app/content/:collection_name/*/*.:locale.md`).  The former logic is now added in this PR and could be shipped as-is.

Tentative implementation then looks like:
```
# config/routes.rb
scope "(:locale)", locale: /de/, defaults: { locale: :en } do
  resources :articles, path: "docs", module: :content, only: %w[index show]
end
```

```
# config/initializer/locale.rb
I18n.available_locales = [:en, :de]
I18n.default_locale = :en
```

Biggest unknown now is how to add these locale-based routes to the build step.

Closes: https://github.com/Rails-Designer/perron/issues/128