### PR TITLE
Improve data errors output

### DIFF
--- a/test/dummy/app/content/data/malformed_csv.csv
+++ b/test/dummy/app/content/data/malformed_csv.csv
@@ -1,0 +1,4 @@
+name,email,role
+John,john@example.com,admin
+Jane,jane@example.com
+Bob,bob@example.com,user,extra_column

--- a/test/dummy/app/content/data/malformed_json.json
+++ b/test/dummy/app/content/data/malformed_json.json
@@ -1,0 +1,12 @@
+{
+  "users": [
+    {
+      "name": "John",
+      "email": "john@example.com"
+    }
+    {
+      "name": "Jane",
+      "email": "jane@example.com"
+    }
+  ]
+}

--- a/test/dummy/app/content/data/malformed_yml.yml
+++ b/test/dummy/app/content/data/malformed_yml.yml
@@ -1,0 +1,6 @@
+- name: John
+  email: john@example.com
+- name: Jane
+  email: jane@example.com
+    invalid_indentation: true
+- name: Bob

--- a/test/perron/data_test.rb
+++ b/test/perron/data_test.rb
@@ -231,4 +231,29 @@ class Perron::Site::DataTest < ActiveSupport::TestCase
     assert_equal "Kendall", data[1].name
     assert_nil data[2]
   end
+
+  test "raises DataParseError for malformed CSV with column mismatch" do
+    error = assert_raises Perron::Errors::DataParseError do
+      Content::Data.new("malformed_csv")
+    end
+
+    assert_includes error.message, "Column mismatch"
+    assert_includes error.message, "Expected: name, email, role"
+  end
+
+  test "raises DataParseError for malformed JSON" do
+    error = assert_raises Perron::Errors::DataParseError do
+      Content::Data.new("malformed_json")
+    end
+
+    assert_includes error.message, "Invalid JSON syntax"
+  end
+
+  test "raises DataParseError for malformed YAML" do
+    error = assert_raises Perron::Errors::DataParseError do
+      Content::Data.new("malformed_yml")
+    end
+
+    assert_includes error.message, "Invalid YAML syntax"
+  end
 end


### PR DESCRIPTION
Recently worked on a site that heavily uses Perron's [programmatic content feature](https://perron.railsdesigner.com/docs/programmatic-content-creation/). Pretty cool, unless you have errors in your data files. Commas within your CSV values (and they are not wrapped in quotes) 😱

This should improve those errors. Example:
```
rails perron:sync_sources
bin/rails aborted!
Perron::Errors::DataParseError: Column mismatch in `~/site/app/content/data/platforms.csv` at row 8 (). Expected: id, name, description, contact_file_path, post_layout_path, default_layout_path, common_use_cases (Perron::Errors::DataParseError)
```

