### PR TITLE
Use `find!` in generated controller

### DIFF
--- a/lib/generators/rails/content/templates/controller.rb.tt
+++ b/lib/generators/rails/content/templates/controller.rb.tt
@@ -1,8 +1,4 @@
 class Content::<%= plural_class_name %>Controller < ApplicationController
-<%- if pages_controller? -%>
-  include Perron::Root
-<%- end -%>
-
 <%- if actions.include?("index") -%>
   def index
     @resources = Content::<%= class_name %>.all
@@ -11,7 +7,7 @@ class Content::<%= plural_class_name %>Controller < ApplicationController
 <%- end -%>
 <%- if actions.include?("show") -%>
   def show
-    @resource = Content::<%= class_name %>.find(params[:id])
+    @resource = Content::<%= class_name %>.find!(params[:id])
   end
 <%- end -%>
 end

--- a/test/generators/perron/content_generator_test.rb
+++ b/test/generators/perron/content_generator_test.rb
@@ -14,6 +14,7 @@ class ContentGeneratorTest < Rails::Generators::TestCase
 
     assert_file "app/models/content/post.rb", /class Content::Post/
     assert_file "app/controllers/content/posts_controller.rb", /class Content::PostsController/
+    assert_file "app/controllers/content/posts_controller.rb", /@resource = Content::Post.find!\(params\[:id\]\)/
 
     assert_file "app/views/content/posts/index.html.erb"
     assert_file "app/views/content/posts/show.html.erb"


### PR DESCRIPTION
Using `find!` in generated controller, instead of `find`. `find!` will raise a NotFound error similar to Rails, instead on returning `nil` (and cause issues later in the rendering process).