### PR TITLE
Added preview indicator when serving output

### DIFF
--- a/lib/perron/output_server.rb
+++ b/lib/perron/output_server.rb
@@ -27,20 +27,25 @@ module Perron
 
     def serve(file_path)
       content = File.read(file_path)
+      injected_content = inject_preview_indicator(content)
 
       [
         200,
 
         {
           "Content-Type" => "text/html; charset=utf-8",
-          "Content-Length" => content.bytesize.to_s
+          "Content-Length" => injected_content.bytesize.to_s
         },
 
-        [content]
+        [injected_content]
       ]
     end
 
     def enabled? = Dir.exist?(output_path)
+
+    def inject_preview_indicator(content)
+      content.gsub(/<title>(.*?)<\/title>/i, "<title>[PREVIEW] \\1</title>")
+    end
 
     def output_path
       @output_path ||= Rails.root.join(Perron.configuration.output)


### PR DESCRIPTION
When you run `bin/rails perron:build`, `bin/dev` will serve the rendered/generated static files (from `/output/`). Super useful to check an actual generated site, but sometimes you forget and are wondering why your changes aren't showing up.

This PR prepends `[PREVIEW]` to the title:
![preview-indicator](https://github.com/user-attachments/assets/b4168b7f-70f9-49f1-8352-b706c822d9e8)

Useful? Too little? Too much? Make it optional?

