### PR TITLE
Return Perron::Relation from has_many associations

### DIFF
--- a/lib/perron/resource/associations.rb
+++ b/lib/perron/resource/associations.rb
@@ -66,7 +66,7 @@ module Perron
       def records_for_ids(associated_class, ids)
         ids = Array(ids)
 
-        associated_class.all.select { ids.include?(it[:id]) || ids.include?(it["id"]) }
+        Perron::Relation.new(associated_class.all.select { ids.include?(it[:id]) || ids.include?(it["id"]) })
       end
 
       def records_for_foreign_key(associated_class, association_name, **options)
@@ -74,7 +74,7 @@ module Perron
         primary_key_method = options.fetch(:primary_key, :slug)
         lookup_value = public_send(primary_key_method)
 
-        associated_class.all.select { it.association_value(foreign_key) == lookup_value }
+        Perron::Relation.new(associated_class.all.select { it.association_value(foreign_key) == lookup_value })
       end
 
       def inverse_association_name = self.class.name.demodulize.underscore

--- a/test/perron/resource/associations_test.rb
+++ b/test/perron/resource/associations_test.rb
@@ -62,4 +62,16 @@ class Perron::Resource::AssociationsTest < ActiveSupport::TestCase
 
     assert_equal "Cam", post.editor.name
   end
+
+  test "has_many returns a Perron::Relation" do
+    posts = @author.posts
+
+    assert_kind_of Perron::Relation, posts
+  end
+
+  test "has_many result supports chaining scopes" do
+    posts = @author.posts.ordered
+
+    assert_kind_of Perron::Relation, posts
+  end
 end


### PR DESCRIPTION
When implementing the new ActiveRecord-style relations, I noticed that `has_many` associations were returning arrays, and so I couldn't use the built in `limit`, `where` helpers, or custom scopes I'd set on the associated model.

## Problem

`has_many` associations call `Array#select` on a `Perron::Relation`, which drops the return type to a plain `Array`. This makes it impossible to chain scopes on association results:

```ruby
# NoMethodError
category.posts.limit(5)

# Workaround required
Perron::Relation.new(category.posts).limit(5)
```

## Solution

Wrap the `select` results in `Perron::Relation` in both `records_for_ids` and `records_for_foreign_key`, so associations support the same chainable API as class-level queries:

```ruby
# Just works
category.posts.limit(5)
category.posts.where(featured: true).limit(5)
```

This should be backwards-compatible since `Perron::Relation < Array` — all existing code that treats association results as arrays continues to work.

## Changes

- Wrap `select` results in `Perron::Relation.new(...)` in `records_for_ids` and `records_for_foreign_key`
- Add tests verifying `has_many` returns a `Perron::Relation` and supports scope chaining