### PR TITLE
Some feed rendering fixes

### DIFF
--- a/lib/perron/site/builder/feeds/json.rb
+++ b/lib/perron/site/builder/feeds/json.rb
@@ -18,25 +18,14 @@ module Perron
           def generate
             return nil if resources.empty?
 
-            hash = Rails.application.routes.url_helpers.with_options(@configuration.default_url_options) do |url|
-              {
-                generator: "Perron (#{Perron::VERSION})",
-                version: "https://jsonfeed.org/version/1.1",
-                home_page_url: @configuration.url,
-                title: feed_configuration.title.presence || @configuration.site_name,
-                description: feed_configuration.description.presence || @configuration.site_description,
-                items: resources.map do |resource|
-                  {
-                    id: resource.id,
-                    url: url.polymorphic_url(resource, ref: feed_configuration.ref).delete_suffix("?ref="),
-                    date_published: resource.published_at&.iso8601,
-                    authors: authors(resource),
-                    title: resource.metadata.title,
-                    content_html: Perron::Markdown.render(resource.content)
-                  }
-                end
-              }
-            end
+            hash = {
+              generator: "Perron (#{Perron::VERSION})",
+              version: "https://jsonfeed.org/version/1.1",
+              home_page_url: @configuration.url,
+              title: feed_configuration.title.presence || @configuration.site_name,
+              description: feed_configuration.description.presence || @configuration.site_description,
+              items: resources.filter_map { jsonify(it) }
+            }
 
             JSON.pretty_generate hash
           end
@@ -51,7 +40,24 @@ module Perron
               .take(feed_configuration.max_items)
           end
 
-          def feed_configuration = @collection.configuration.feeds.json
+          def jsonify(resource)
+            {
+              id: resource.id,
+              url: url_for_resource(resource),
+              date_published: resource.published_at&.iso8601,
+              authors: authors(resource),
+              title: resource.metadata.title,
+              content_html: Perron::Markdown.render(resource.content)
+            }.compact
+          end
+
+          def url_for_resource(resource)
+            routes
+              .polymorphic_url(resource, **@configuration.default_url_options.merge(ref: feed_configuration.ref))
+              .delete_suffix("?ref=")
+          rescue
+            nil
+          end
 
           def authors(resource)
             author = author(resource)
@@ -60,6 +66,10 @@ module Perron
 
             [{name: author.name, email: author.email, url: author.url, avatar: author.avatar}.compact].presence
           end
+
+          def feed_configuration = @collection.configuration.feeds.json
+
+          def routes = Rails.application.routes.url_helpers
         end
       end
     end

--- a/lib/perron/site/builder/feeds/rss.rb
+++ b/lib/perron/site/builder/feeds/rss.rb
@@ -26,20 +26,22 @@ module Perron
                   xml.description feed_configuration.description.presence || @configuration.site_description
                   xml.link @configuration.url
 
-                  Rails.application.routes.url_helpers.with_options(@configuration.default_url_options) do |url|
-                    resources.each do |resource|
-                      xml.item do
-                        xml.guid resource.id
-                        xml.link url.polymorphic_url(resource, ref: feed_configuration.ref).delete_suffix("?ref="), isPermaLink: true
-                        xml.pubDate(resource.published_at&.rfc822)
+                  resources.each do |resource|
+                    xml.item do
+                      xml.guid resource.id, isPermaLink: false
 
-                        if (author = author(resource)) && author.email
-                          xml.author author.name ? "#{author.email} (#{author.name})" : author.email
-                        end
-
-                        xml.title resource.metadata.title
-                        xml.description { xml.cdata(Perron::Markdown.render(resource.content)) }
+                      if (resource_url = url_for_resource(resource))
+                        xml.link resource_url
                       end
+
+                      xml.pubDate(resource.published_at&.rfc822)
+
+                      if (author = author(resource)) && author.email
+                        xml.author author.name ? "#{author.email} (#{author.name})" : author.email
+                      end
+
+                      xml.title resource.metadata.title
+                      xml.description { xml.cdata(Perron::Markdown.render(resource.content)) }
                     end
                   end
                 end
@@ -57,7 +59,17 @@ module Perron
               .take(feed_configuration.max_items)
           end
 
+          def url_for_resource(resource)
+            routes
+              .polymorphic_url(resource, **@configuration.default_url_options.merge(ref: feed_configuration.ref))
+              .delete_suffix("?ref=")
+          rescue
+            nil
+          end
+
           def feed_configuration = @collection.configuration.feeds.rss
+
+          def routes = Rails.application.routes.url_helpers
         end
       end
     end

--- a/test/perron/site/builder/feeds/rss_test.rb
+++ b/test/perron/site/builder/feeds/rss_test.rb
@@ -83,6 +83,16 @@ class Perron::Site::Builder::Feeds::RssTest < ActiveSupport::TestCase
     end
   end
 
+  test "sets permaLink=false to guid" do
+    @posts.configuration.feeds.rss.stub(:ref, "perron.railsdesigner.com") do
+      @posts.configuration.feeds.rss.stub(:max_items, 1) do
+        rss = Nokogiri::XML(@builder.generate).remove_namespaces!
+
+        assert rss.at_xpath("//item/guid").attributes["isPermaLink"].value, false
+      end
+    end
+  end
+
   test "sets a `ref` param to the link" do
     @posts.configuration.feeds.rss.stub(:ref, "perron.railsdesigner.com") do
       @posts.configuration.feeds.rss.stub(:max_items, 1) do


### PR DESCRIPTION
Tested XML generated feeds against w3c validator and made some changes. Still cannot get `atom:link` tag to be included (see: https://validator.w3.org/feed/docs/warning/MissingAtomSelfLink.html). I think Nokogiri here is the limiting factor. Will wait for https://github.com/Rails-Designer/perron/issues/61 to be added.

Also some changes to the created JSON feed to exclude any key/value (most notably the url key). 