### PR TITLE
Option to define `collection_name` on controller

### DIFF
--- a/lib/perron/site/builder/paths.rb
+++ b/lib/perron/site/builder/paths.rb
@@ -80,9 +80,12 @@ module Perron
         private
 
         def standard_collection(route)
-          collection_name = route.defaults[:controller].split("/").last.chomp("_controller")
+          controller_class = "#{route.defaults[:controller]}_controller".classify.constantize
+          collection_name = controller_class.respond_to?(:collection_name) ? controller_class.collection_name : route.defaults[:controller].split("/").last.chomp("_controller")
 
           Perron::Site.find_collection(collection_name)
+        rescue NameError
+          Perron::Site.find_collection(route.defaults[:controller].split("/").last.chomp("_controller"))
         end
 
         def parent_collection(route)

--- a/test/dummy/app/controllers/content/members_controller.rb
+++ b/test/dummy/app/controllers/content/members_controller.rb
@@ -1,0 +1,9 @@
+class Content::MembersController < ApplicationController
+  def self.collection_name = "pages"
+
+  def index
+  end
+
+  def show
+  end
+end

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
   end
   resources :features, path: "features", module: :content, only: %w[show]
   resources :pages, path: "/", module: :content, only: %w[show]
+  resources :members, module: :content, path: "team", only: %w[index show]
   resources :posts, path: "blog", module: :content, only: %w[index show] do
     resource :template, path: "template.rb", module: :posts, only: %w[show]
   end

--- a/test/perron/site/builder/paths_test.rb
+++ b/test/perron/site/builder/paths_test.rb
@@ -54,4 +54,11 @@ class Perron::Site::Builder::PathsTest < ActiveSupport::TestCase
     assert_includes @paths, "/blog/rails"
     assert_includes @paths, "/blog/css"
   end
+
+  test "uses collection_name when controller overrides default mapping" do
+    @paths_builder.get
+
+    assert_includes @paths, "/team", "Should include page resource"
+    assert_includes @paths, "/team/about", "Should include page resource"
+  end
 end


### PR DESCRIPTION
Adds support for setting a collection_name on a controller. This could be useful if a collection has the same properties (frontmatter, etc.) as another collection.

Example:
```ruby
class Content::MembersController < ApplicationController
  def self.collection_name = "pages"

  def show
  end
end
```

```ruby
resources :members, module: :content, path: "team", only: %w[show]
```

Now you can have `cam.md`, `kendall.md` and `chris.md` in `app/content/pages` and they will be rendered correctly. No need to set up `Content::Member`. Most commonly you want to add constraints to the above route as well:
```ruby
resources :members, module: :content, path: "team", contraints: {id: /cam|kendall|chris/}, only: %w[show]
```

This is slightly obscure, but I've stumbled upon up this multiple times now.