### PR TITLE
Don't suppress assets:precompile output

### DIFF
--- a/lib/perron/site/builder/assets.rb
+++ b/lib/perron/site/builder/assets.rb
@@ -11,7 +11,7 @@ module Perron
         def prepare
           puts "📦 Precompiling and copying assets…"
 
-          success = system("bundle exec rails assets:precompile")
+          success = system("bundle exec rails assets:precompile", out: File::NULL)
 
           unless success
             puts "❌ ERROR: Asset precompilation failed"


### PR DESCRIPTION
Quite simple change, and original code is certainly intended, but i can't imagine a case where someone would want to completely suppress stderr of a system call. My case is forgetting in `SECRET_KEY_BASE_DUMMY: 1` in CI, but there are many possible reasons for a system call to fail.