### PR TITLE
Added option for Atom feeds

### DIFF
--- a/lib/perron/feeds.rb
+++ b/lib/perron/feeds.rb
@@ -32,8 +32,9 @@ module Perron
     private
 
     MIME_TYPES = {
-      rss: "application/rss+xml",
-      json: "application/json"
+      atom: "application/atom+xml",
+      json: "application/json",
+      rss: "application/rss+xml"
     }
   end
 end

--- a/lib/perron/resource/configuration.rb
+++ b/lib/perron/resource/configuration.rb
@@ -12,15 +12,20 @@ module Perron
 
             config.feeds = Options.new
 
-            config.feeds.rss = ActiveSupport::OrderedOptions.new
-            config.feeds.rss.enabled = false
-            config.feeds.rss.path = "feeds/#{collection.name.demodulize.parameterize}.xml"
-            config.feeds.rss.max_items = 20
+            config.feeds.atom = ActiveSupport::OrderedOptions.new
+            config.feeds.atom.enabled = false
+            config.feeds.atom.path = "feeds/#{collection.name.demodulize.parameterize}.xml"
+            config.feeds.atom.max_items = 20
 
             config.feeds.json = ActiveSupport::OrderedOptions.new
             config.feeds.json.enabled = false
             config.feeds.json.path = "feeds/#{collection.name.demodulize.parameterize}.json"
             config.feeds.json.max_items = 20
+
+            config.feeds.rss = ActiveSupport::OrderedOptions.new
+            config.feeds.rss.enabled = false
+            config.feeds.rss.path = "feeds/#{collection.name.demodulize.parameterize}.xml"
+            config.feeds.rss.max_items = 20
 
             config.related_posts = ActiveSupport::OrderedOptions.new
             config.related_posts.enabled = false

--- a/lib/perron/site/builder/feeds.rb
+++ b/lib/perron/site/builder/feeds.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
-require "perron/site/builder/feeds/rss"
+require "perron/site/builder/feeds/atom"
 require "perron/site/builder/feeds/json"
+require "perron/site/builder/feeds/rss"
 
 module Perron
   module Site
@@ -17,12 +18,16 @@ module Perron
 
             config = collection.configuration.feeds
 
-            if config.rss.enabled
-              create_file at: config.rss.path, with: Rss.new(collection: collection).generate
+            if config.atom.enabled
+              create_file at: config.atom.path, with: Atom.new(collection: collection).generate
             end
 
             if config.json.enabled
               create_file at: config.json.path, with: Json.new(collection: collection).generate
+            end
+
+            if config.rss.enabled
+              create_file at: config.rss.path, with: Rss.new(collection: collection).generate
             end
           end
         end

--- a/lib/perron/site/builder/feeds/atom.rb
+++ b/lib/perron/site/builder/feeds/atom.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require "nokogiri"
+require "perron/site/builder/feeds/author"
+
+module Perron
+  module Site
+    class Builder
+      class Feeds
+        class Atom
+          include Feeds::Author
+
+          def initialize(collection:)
+            @collection = collection
+            @configuration = Perron.configuration
+          end
+
+          def generate
+            return if resources.empty?
+
+            Nokogiri::XML::Builder.new(encoding: "UTF-8") do |xml|
+              xml.feed(xmlns: "http://www.w3.org/2005/Atom") do
+                xml.generator "Perron", uri: @configuration.url, version: Perron::VERSION
+                xml.id current_feed_url
+                xml.title feed_configuration.title.presence || @configuration.site_name
+                xml.subtitle feed_configuration.description.presence || @configuration.site_description
+                xml.link href: current_feed_url, rel: "self", type: "application/atom+xml"
+                xml.link href: @configuration.url, rel: "alternate", type: "text/html"
+                xml.updated resources.first&.published_at&.iso8601 || Time.current.iso8601
+
+                feed_author = feed_configuration.author || {
+                  name: @configuration.site_name,
+                  email: "noreply@#{URI.parse(@configuration.url).host}"
+                }
+
+                xml.author do
+                  xml.name feed_author[:name] if feed_author[:name]
+                  xml.email feed_author[:email] if feed_author[:email]
+                end
+
+                resources.each do |resource|
+                  xml.entry do
+                    xml.title resource.metadata.title
+                    xml.link href: url_for_resource(resource), rel: "alternate", type: "text/html"
+                    xml.published resource.published_at&.iso8601
+                    xml.updated (resource.metadata.updated_at || resource.published_at)&.iso8601
+                    xml.id url_for_resource(resource) || "#{@configuration.url}/posts/#{resource.id}"
+
+                    if (entry_author = author(resource))
+                      xml.author do
+                        xml.name entry_author.name if entry_author.name
+                        xml.email entry_author.email if entry_author.email
+                      end
+                    end
+
+                    if (base_url = url_for_resource(resource))
+                      xml.content :type => "html", "xml:base" => base_url do
+                        xml.cdata(Perron::Markdown.render(resource.content))
+                      end
+                    else
+                      xml.content type: "html" do
+                        xml.cdata(Perron::Markdown.render(resource.content))
+                      end
+                    end
+
+                    resource.metadata.tags&.each do |tag|
+                      xml.category term: tag
+                    end
+                  end
+                end
+              end
+            end.to_xml
+          end
+
+          private
+
+          def resources
+            @resource ||= @collection.resources
+              .reject { it.metadata.feed == false }
+              .sort_by { it.metadata.published_at || it.metadata.updated_at || Time.current }
+              .reverse
+              .take(feed_configuration.max_items)
+          end
+
+          def url_for_resource(resource)
+            routes
+              .polymorphic_url(resource, **@configuration.default_url_options.merge(ref: feed_configuration.ref))
+              .delete_suffix("?ref=")
+          rescue
+            nil
+          end
+
+          def current_feed_url
+            path = feed_configuration.path || "feed.atom"
+
+            URI.join(@configuration.url, path).to_s
+          end
+
+          def feed_configuration = @collection.configuration.feeds.atom
+
+          def routes = Rails.application.routes.url_helpers
+        end
+      end
+    end
+  end
+end

--- a/test/dummy/app/models/content/post.rb
+++ b/test/dummy/app/models/content/post.rb
@@ -8,13 +8,18 @@ class Content::Post < Perron::Resource
   configure do |config|
     config.sitemap.enabled = false
 
-    config.feeds.rss.author = {
-      name: "RSS Config Author",
+    config.feeds.atom.author = {
+      name: "Atom Config Author",
       email: "support@railsdesigner.com"
     }
 
     config.feeds.json.author = {
       name: "JSON Config Author",
+      email: "support@railsdesigner.com"
+    }
+
+    config.feeds.rss.author = {
+      name: "RSS Config Author",
       email: "support@railsdesigner.com"
     }
 

--- a/test/perron/feeds_test.rb
+++ b/test/perron/feeds_test.rb
@@ -2,27 +2,30 @@ require "test_helper"
 
 class Perron::FeedsTest < ActionDispatch::IntegrationTest
   setup do
-    Content::Post.configure { |it| it.feeds.rss.enabled = true }
-    Content::Page.configure { |it| it.feeds.rss.enabled = true }
+    Content::Post.configure { it.feeds.rss.enabled = true }
+    Content::Post.configure { it.feeds.atom.enabled = true }
+    Content::Page.configure { it.feeds.rss.enabled = true }
   end
 
   teardown do
-    Content::Post.configure { |it| it.feeds.rss.enabled = false }
-    Content::Page.configure { |it| it.feeds.rss.enabled = false }
+    Content::Post.configure { it.feeds.rss.enabled = false }
+    Content::Post.configure { it.feeds.atom.enabled = false }
+    Content::Page.configure { it.feeds.rss.enabled = false }
   end
 
   test "renders all enabled feeds by default" do
     document = rendered_document
 
     assert_select document, 'link[rel="alternate"][type="application/rss+xml"][title="Posts RSS Feed"][href*="feeds/posts.xml"]', count: 1
-    assert_select document, 'link[rel="alternate"][href*="feeds/pages.xml"]', count: 1, message: "Could not find feed link for 'pages'. Ensure it is configured with an enabled feed in the dummy app."
+    assert_select document, 'link[rel="alternate"][type="application/atom+xml"][title="Posts ATOM Feed"][href*="feeds/posts.xml"]', count: 1
+    assert_select document, 'link[rel="alternate"][type="application/rss+xml"][href*="feeds/pages.xml"]', count: 1
     assert_select document, 'link[href*="posts.json"]', count: 0
   end
 
   test "renders only specified collections using :only option" do
     document = rendered_document(only: [:posts])
 
-    assert_select document, 'link[href*="feeds/posts.xml"]', count: 1
+    assert_select document, 'link[href*="feeds/posts.xml"]', count: 2, message: "Renders for both RSS and Atom feeds"
     assert_select document, 'link[href*="feeds/pages.xml"]', count: 0, message: "Pages feed should be excluded"
   end
 

--- a/test/perron/site/builder/feeds/atom_test.rb
+++ b/test/perron/site/builder/feeds/atom_test.rb
@@ -1,0 +1,125 @@
+require "test_helper"
+
+class Perron::Site::Builder::Feeds::AtomTest < ActiveSupport::TestCase
+  include ConfigurationHelper
+
+  setup do
+    @posts = Perron::Site.collection("posts")
+    @builder = Perron::Site::Builder::Feeds::Atom.new(collection: @posts)
+  end
+
+  test "generates correct Atom string with entries sorted by date" do
+    @posts.configuration.feeds.atom.stub(:max_items, 10) do
+      atom = Nokogiri::XML(@builder.generate).remove_namespaces!
+
+      assert_equal "Perron", atom.at_xpath("//generator").text
+      assert_equal "http://localhost:3000/", atom.at_xpath("//generator").attributes["uri"].value
+      assert_equal Perron::VERSION, atom.at_xpath("//generator").attributes["version"].value
+      assert_equal "Dummy App", atom.at_xpath("//title").text
+      assert_equal "", atom.at_xpath("//subtitle").text
+
+      self_link = atom.at_xpath("//link[@rel='self']")
+      assert_equal "application/atom+xml", self_link.attributes["type"].value
+
+      alternate_link = atom.at_xpath("//link[@rel='alternate']")
+      assert_equal "http://localhost:3000/", alternate_link.attributes["href"].value
+      assert_equal "text/html", alternate_link.attributes["type"].value
+
+      entries = atom.xpath("//entry")
+      assert_operator entries.count, :>, 0, "Should include at least one post"
+
+      published_dates = entries.xpath("published").map { Time.parse(it.text) }
+      assert_equal published_dates.sort.reverse, published_dates, "Posts should be sorted by date descending"
+    end
+  end
+
+  test "respects max_items configuration" do
+    @posts.configuration.feeds.atom.stub(:max_items, 1) do
+      atom = Nokogiri::XML(@builder.generate).remove_namespaces!
+
+      assert_equal 1, atom.xpath("//entry").count
+    end
+  end
+
+  test "configured feed name and description" do
+    @posts.configuration.feeds.atom.stub(:title, "Custom Atom title") do
+      atom = Nokogiri::XML(@builder.generate).remove_namespaces!
+
+      assert_equal "Custom Atom title", atom.at_xpath("//title").text
+    end
+
+    @posts.configuration.feeds.atom.stub(:description, "Custom Atom description") do
+      atom = Nokogiri::XML(@builder.generate).remove_namespaces!
+
+      assert_equal "Custom Atom description", atom.at_xpath("//subtitle").text
+    end
+  end
+
+  test "uses polymorphic links for entries" do
+    @posts.configuration.feeds.atom.stub(:max_items, 1) do
+      atom = Nokogiri::XML(@builder.generate).remove_namespaces!
+
+      link = atom.at_xpath("//entry/link[@rel='alternate']").attributes["href"].value
+      assert_match %r{^http://localhost:3000/blog/.+/$}, link, "Should be a valid blog post URL"
+    end
+  end
+
+  test "includes author when present" do
+    @posts.configuration.feeds.atom.stub(:max_items, 10) do
+      atom = Nokogiri::XML(@builder.generate).remove_namespaces!
+
+      entry_with_author = atom.xpath("//entry").find do |entry|
+        entry.at_xpath("title").text == "Sample Post"
+      end
+
+      assert_not_nil entry_with_author, "Sample Post should exist in feed"
+      author_name = entry_with_author.at_xpath("author/name")
+      author_email = entry_with_author.at_xpath("author/email")
+
+      assert_equal "Rails Designer", author_name.text
+      assert_equal "support@railsdesigner.com", author_email.text
+    end
+  end
+
+  test "includes author from config when belongs_to author not defined" do
+    @posts.configuration.feeds.atom.stub(:max_items, 10) do
+      atom = Nokogiri::XML(@builder.generate).remove_namespaces!
+
+      entries_with_config_author = atom.xpath("//entry").select do |entry|
+        author_name = entry.at_xpath("author/name")&.text
+        author_name == "Atom Config Author"
+      end
+
+      assert_operator entries_with_config_author.count, :>, 0, "Should have at least one post using config author"
+    end
+  end
+
+  test "includes required id elements" do
+    @posts.configuration.feeds.atom.stub(:max_items, 1) do
+      atom = Nokogiri::XML(@builder.generate).remove_namespaces!
+
+      assert_not_nil atom.at_xpath("//id"), "Feed should have id element"
+      assert_not_nil atom.at_xpath("//entry/id"), "Entry should have id element"
+    end
+  end
+
+  test "includes content with correct type" do
+    @posts.configuration.feeds.atom.stub(:max_items, 1) do
+      atom = Nokogiri::XML(@builder.generate).remove_namespaces!
+
+      content = atom.at_xpath("//entry/content")
+      assert_equal "html", content.attributes["type"].value
+    end
+  end
+
+  test "sets a `ref` param to the link" do
+    @posts.configuration.feeds.atom.stub(:ref, "perron.railsdesigner.com") do
+      @posts.configuration.feeds.atom.stub(:max_items, 1) do
+        atom = Nokogiri::XML(@builder.generate).remove_namespaces!
+
+        link = atom.at_xpath("//entry/link[@rel='alternate']").attributes["href"].value
+        assert_match %r{\?ref=perron\.railsdesigner\.com$}, link, "Should include ref parameter"
+      end
+    end
+  end
+end


### PR DESCRIPTION
Atom offers richer metadata and better content semantics than RSS 2.0

Similar API as RSS/JSON feeds: 
```ruby
class Content::Post < Perron::Resource
  # …
  configure do |config|
    config.feeds.atom.enabled = true
    config.feeds.atom.title = "Rails Designer Blog"
    config.feeds.atom.description = "Articles from Rails Designer Blog"
    config.feeds.atom.path = "feed.xml"
    config.feeds.atom.max_items = 25
    config.feeds.atom.ref = "atom"
  end
  #…
end
```