### PR TITLE
Make filename generation for, e.g. `rails g content Post --new` more flexible

### DIFF
--- a/lib/generators/rails/content/content_generator.rb
+++ b/lib/generators/rails/content/content_generator.rb
@@ -131,17 +131,17 @@ module Rails
       def pages_controller? = plural_file_name == "pages"
 
       def template_file
-        @template_file ||= Dir.glob(File.join(content_directory, "{YYYY-MM-DD-,}template.*.tt")).first
+        @template_file ||= Dir.glob(File.join(content_directory, "*template.*.tt")).first
       end
 
       def filename_from_template
         @filename_from_template ||= begin
           return "untitled.md" unless template_file
 
-          File.basename(template_file, ".tt").tap do |name|
-            name.gsub!("YYYY-MM-DD", Time.current.strftime("%Y-%m-%d"))
-            name.sub!("template", @content_title ? @content_title.parameterize : "untitled")
-          end
+          name = File.basename(template_file, ".tt")
+          name = Time.current.strftime(name)
+
+          name.sub("template", @content_title ? @content_title.parameterize : "untitled")
         end
       end
 

--- a/test/generators/perron/content_generator_test.rb
+++ b/test/generators/perron/content_generator_test.rb
@@ -54,6 +54,30 @@ class ContentGeneratorTest < Rails::Generators::TestCase
     assert_no_file "app/controllers/content/posts_controller.rb"
   end
 
+  test "--new with strftime template creates timestamped file" do
+    FileUtils.mkdir_p(File.join(destination_root, "app", "content", "posts"))
+    File.write(File.join(destination_root, "app", "content", "posts", "%s-template.md.tt"), "---\ntitle: <%= @title %>\n---\n")
+
+    freeze_time do
+      run_generator ["post", "--new=My Post"]
+
+      timestamp = Time.current.strftime("%s")
+      assert_file "app/content/posts/#{timestamp}-my-post.md", /---\ntitle: My Post\n---\n/
+    end
+  end
+
+  test "--new with day template creates day-prefixed file" do
+    FileUtils.mkdir_p(File.join(destination_root, "app", "content", "posts"))
+    File.write(File.join(destination_root, "app", "content", "posts", "%d-template.md.tt"), "---\ntitle: <%= @title %>\n---\n")
+
+    freeze_time do
+      run_generator ["post", "--new=Daily Note"]
+
+      day = Time.current.strftime("%d")
+      assert_file "app/content/posts/#{day}-daily-note.md", /---\ntitle: Daily Note\n---\n/
+    end
+  end
+
   test "pages generates root action and route by default" do
     run_generator %w[page]
 


### PR DESCRIPTION
- `%s-template.md.tt` → `1709337600-my-post.md`
- `%Y-%m-%d-template.md.tt` → `2026-03-02-my-post.md`
- `%d-template.md.tt` → `02-my-post.md`

And so on. Every [strftime](https://docs.ruby-lang.org/en/master/language/strftime_formatting_rdoc.html) specifier is supported.