### PR TITLE
Added middleware to catch feed + sitemap render in development

### DIFF
--- a/lib/perron/development_feed_server.rb
+++ b/lib/perron/development_feed_server.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+module Perron
+  class DevelopmentFeedServer
+    def initialize(app)
+      @app = app
+    end
+
+    def call(environment)
+      request = Rack::Request.new(environment)
+
+      if build_only_path?(request.path_info)
+        render_message(request.path_info)
+      else
+        @app.call(environment)
+      end
+    end
+
+    private
+
+    def build_only_path?(path)
+      sitemap?(path) || feed?(path)
+    end
+
+    def render_message(path)
+      content_type = path.end_with?(".json") ? "application/json" : "application/xml"
+
+      [
+        200,
+
+        {
+          "Content-Type" => "#{content_type}; charset=utf-8",
+          "Content-Length" => message(path).bytesize.to_s
+        },
+
+        [message(path)]
+      ]
+    end
+
+    def sitemap?(path)
+      path.match?(/\/sitemap\.xml$/)
+    end
+
+    def feed?(path)
+      feed_paths.any? { path.end_with?("/#{it}") || path == "/#{it}" }
+    end
+
+    def message(path)
+      if path.end_with?(".json")
+        "{ \"message\": \"This feed is generated during build\" }"
+      elsif sitemap?(path)
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">\n  <!-- Sitemap is generated during build -->\n</urlset>"
+      else
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<feed xmlns=\"http://www.w3.org/2005/Atom\">\n  <!-- Feed is generated during build -->\n</feed>"
+      end
+    end
+
+    def feed_paths
+      @feed_paths ||= Perron::Site.collections.flat_map do |collection|
+        config = collection.configuration
+        next [] unless config && config[:feeds]
+
+        config[:feeds].values.filter_map do |feed_config|
+          feed_config[:path] if feed_config[:enabled]
+        end
+      end.compact
+    end
+  end
+end

--- a/lib/perron/engine.rb
+++ b/lib/perron/engine.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "perron/output_server"
+require "perron/development_feed_server"
 require "mata"
 
 module Perron
@@ -11,6 +12,10 @@ module Perron
 
     initializer "perron.output_server" do |app|
       app.middleware.use Perron::OutputServer
+    end
+
+    initializer "perron.development_feed_server" do |app|
+      app.middleware.use Perron::DevelopmentFeedServer if Rails.env.development?
     end
 
     initializer "perron.configure_hmr", after: :load_config_initializers do |app|


### PR DESCRIPTION
Closes https://github.com/Rails-Designer/perron/issues/94

Feeds or sitemap creation only happens during build. This PR adds middleware to catch feeds + sitemap paths and shows a message as such.

This is for better DX and only in development.

![sitemapxml-devel](https://github.com/user-attachments/assets/6bd57368-fe49-4501-a455-ce0fb68ea906)
