### PR TITLE
Support for @resource access in processors

### DIFF
--- a/app/helpers/perron/markdown_helper.rb
+++ b/app/helpers/perron/markdown_helper.rb
@@ -4,10 +4,10 @@ require "perron/markdown"
 
 module Perron
   module MarkdownHelper
-    def markdownify(content = nil, process: [], &block)
+    def markdownify(content = nil, process: [], resource: nil, &block)
       text = block_given? ? capture(&block).strip_heredoc : content
 
-      Perron::Markdown.render(text, processors: process)
+      Perron::Markdown.render(text, processors: process, resource: resource || @resource)
     end
   end
 end

--- a/lib/perron/html_processor.rb
+++ b/lib/perron/html_processor.rb
@@ -5,14 +5,15 @@ require "perron/html_processor/lazy_load_images"
 
 module Perron
   class HtmlProcessor
-    def initialize(html, processors: [])
+    def initialize(html, processors: [], resource: nil)
       @html = html
+      @resource = resource
       @processors = processors.map { find_by(it) }
     end
 
     def process
       Nokogiri::HTML::DocumentFragment.parse(@html).tap do |document|
-        @processors.each { it.new(document).process }
+        @processors.each { it.new(document, resource: @resource).process }
       end.to_html
     end
 

--- a/lib/perron/html_processor/base.rb
+++ b/lib/perron/html_processor/base.rb
@@ -3,8 +3,8 @@
 module Perron
   class HtmlProcessor
     class Base
-      def initialize(html)
-        @html = html
+      def initialize(html, resource: nil)
+        @html, @resource = html, resource
       end
 
       def process

--- a/lib/perron/markdown.rb
+++ b/lib/perron/markdown.rb
@@ -5,9 +5,9 @@ require "perron/html_processor"
 module Perron
   class Markdown
     class << self
-      def render(text, processors: [])
+      def render(text, processors: [], resource: nil)
         parser.parse(text)
-          .then { Perron::HtmlProcessor.new(it, processors: processors).process }
+          .then { Perron::HtmlProcessor.new(it, processors: processors, resource: resource).process }
           .html_safe
       end
 

--- a/test/dummy/app/content/posts/2023-05-15-sample-post.md
+++ b/test/dummy/app/content/posts/2023-05-15-sample-post.md
@@ -4,6 +4,7 @@ description: Describing sample post
 image: https://example.com/images/sample.jpg
 author_id: rails-designer
 updated_at: 2023-05-15
+processor_class: custom-from-metadata
 ---
 
 Labore qui mollit commodo id nulla qui exercitation nulla reprehenderit nulla excepteur aute eu sint. Minim sit aute et ad ut esse aute sunt magna voluptate duis tempor. Commodo commodo qui amet ullamco Lorem ex cillum ea occaecat deserunt elit amet consequat nulla Lorem. Reprehenderit id aute dolor minim aliquip officia et reprehenderit nisi. Aute labore ex veniam enim enim duis sint elit proident aute sunt consectetur ut aliqua. Laboris elit exercitation veniam non commodo magna sunt in sunt id.

--- a/test/dummy/app/processors/dummy_processor.rb
+++ b/test/dummy/app/processors/dummy_processor.rb
@@ -2,6 +2,6 @@
 
 class DummyProcessor < Perron::HtmlProcessor::Base
   def process
-    @html.css("p").add_class("processed-by-dummy")
+    @html.css("p").add_class(@resource.metadata.processor_class || "processed-by-dummy")
   end
 end

--- a/test/helpers/markdown_helper_test.rb
+++ b/test/helpers/markdown_helper_test.rb
@@ -5,10 +5,20 @@ require "test_helper"
 class MarkdownHelperTest < ActionView::TestCase
   include Perron::MarkdownHelper
 
-  test "passes content and processors correctly through the chain" do
+  test "passes content, processors, and resource correctly through the chain" do
+    @resource = Content::Post.find!("sample-post")
     html = markdownify("<p>Some text.</p>", process: ["dummy_processor"])
 
-    assert_dom_equal '<p class="processed-by-dummy">Some text.</p>', html.strip
+    expected_class = @resource.metadata.dig("processor_class") || "processed-by-dummy"
+    assert_dom_equal %(<p class="#{expected_class}">Some text.</p>), html.strip
+  end
+
+  test "uses explicit resource parameter when provided" do
+    resource = Content::Post.find!("another-post")
+    html = markdownify("<p>Some text.</p>", process: ["dummy_processor"], resource: resource)
+
+    expected_class = resource.metadata.dig("processor_class") || "processed-by-dummy"
+    assert_dom_equal %(<p class="#{expected_class}">Some text.</p>), html.strip
   end
 
   test "renders basic markdown without processors" do

--- a/test/perron/html_processor_test.rb
+++ b/test/perron/html_processor_test.rb
@@ -5,11 +5,12 @@ require "perron/html_processor"
 require "perron/errors"
 
 class Perron::HtmlProcessorTest < ActionView::TestCase
-  test "applies a custom processor specified by a string" do
+  test "applies a custom processor with resource data" do
+    resource = Content::Post.find!("sample-post")
     html_input = "<p>Some text.</p>"
-    processed_html = Perron::HtmlProcessor.new(html_input, processors: ["dummy_processor"]).process
+    processed_html = Perron::HtmlProcessor.new(html_input, processors: ["dummy_processor"], resource: resource).process
 
-    assert_dom_equal '<p class="processed-by-dummy">Some text.</p>', processed_html
+    assert_dom_equal '<p class="custom-from-metadata">Some text.</p>', processed_html
   end
 
   test "applies a built-in processor specified by a string" do


### PR DESCRIPTION
Closes https://github.com/Rails-Designer/perron/issues/62

Processors have now implicitly access to the `@resource` class. This has many use cases, for example:

- build utm params with frontmatter data
- pass what partial to inject using the [inject html processor](https://perron.railsdesigner.com/library/inject-html-processor/)
- conditionally enable/disable processing per resource

If you do not use the conventional `@resource`, you can pass your resource object to the markdownify helper, e.g. `resource: @post`.