### PR TITLE
Add `output_server_strict` config

### DIFF
--- a/lib/perron/configuration.rb
+++ b/lib/perron/configuration.rb
@@ -15,6 +15,8 @@ module Perron
 
       @config.output = "output"
 
+      @config.output_server_strict = false
+
       @config.mode = :standalone
 
       @config.live_reload = false

--- a/lib/perron/output_server.rb
+++ b/lib/perron/output_server.rb
@@ -8,6 +8,7 @@ module Perron
 
     def call(environment)
       return @app.call(environment) if disabled?
+      return not_found if !static_file(environment) && Perron.configuration.output_server_strict
 
       static_file(environment).then do |file|
         file ? serve(file) : @app.call(environment)
@@ -38,6 +39,14 @@ module Perron
         },
 
         [injected_content]
+      ]
+    end
+
+    def not_found
+      [
+        404,
+        {"Content-Type" => "text/plain"},
+        ["Not Found"]
       ]
     end
 


### PR DESCRIPTION
Set `output_server_strict` to true to raise a 404 for missing files when running `bin/dev` after `perron:build`. This change prevents fallback to Rails server/render, avoiding confusion with incorrectly rendered pages.

Considering making this the default setting.