### PR TITLE
Add default_processors configuration option for markdownify

### DIFF
--- a/app/helpers/perron/markdown_helper.rb
+++ b/app/helpers/perron/markdown_helper.rb
@@ -4,10 +4,11 @@ require "perron/markdown"
 
 module Perron
   module MarkdownHelper
-    def markdownify(content = nil, process: [], resource: nil, &block)
+    def markdownify(content = nil, process: nil, resource: nil, &block)
       text = block_given? ? capture(&block).strip_heredoc : content
+      processors = (process.nil? || process.empty?) ? Perron.configuration.default_processors : process
 
-      Perron::Markdown.render(text, processors: process, resource: resource || @resource)
+      Perron::Markdown.render(text, processors: processors, resource: resource || @resource)
     end
   end
 end

--- a/lib/perron/configuration.rb
+++ b/lib/perron/configuration.rb
@@ -35,6 +35,8 @@ module Perron
 
       @config.markdown_options = {}
 
+      @config.default_processors = []
+
       @config.search_scope = []
 
       @config.sitemap = ActiveSupport::OrderedOptions.new

--- a/test/helpers/markdown_helper_test.rb
+++ b/test/helpers/markdown_helper_test.rb
@@ -5,6 +5,16 @@ require "test_helper"
 class MarkdownHelperTest < ActionView::TestCase
   include Perron::MarkdownHelper
 
+  setup do
+    @original_default_processors = Perron.configuration.default_processors
+  end
+
+  teardown do
+    Perron.configure do |config|
+      config.default_processors = @original_default_processors
+    end
+  end
+
   test "passes content, processors, and resource correctly through the chain" do
     @resource = Content::Post.find!("sample-post")
     html = markdownify("<p>Some text.</p>", process: ["dummy_processor"])
@@ -25,5 +35,44 @@ class MarkdownHelperTest < ActionView::TestCase
     html = markdownify("## Hello")
 
     assert_dom_equal "## Hello", html.strip
+  end
+
+  test "uses default_processors from config when none passed" do
+    Perron.configure do |config|
+      config.default_processors = %w[dummy_processor]
+    end
+
+    @resource = Content::Post.find!("sample-post")
+    html = markdownify("<p>Some text.</p>")
+
+    expected_class = @resource.metadata.dig("processor_class") || "processed-by-dummy"
+    assert_dom_equal %(<p class="#{expected_class}">Some text.</p>), html.strip
+  end
+
+  test "uses default_processors from config when empty array passed" do
+    Perron.configure do |config|
+      config.default_processors = %w[dummy_processor]
+    end
+
+    @resource = Content::Post.find!("sample-post")
+    html = markdownify("<p>Some text.</p>", process: [])
+
+    expected_class = @resource.metadata.dig("processor_class") || "processed-by-dummy"
+    assert_dom_equal %(<p class="#{expected_class}">Some text.</p>), html.strip
+  end
+
+  test "explicit process argument overrides default_processors" do
+    Perron.configure do |config|
+      config.default_processors = %w[target_blank]
+    end
+
+    html = markdownify('<a href="http://example.com">Link</a><img src="test.jpg">', process: ["lazy_load_images"])
+
+    assert_includes html, 'loading="lazy"'
+    refute_includes html, 'target="_blank"'
+  end
+
+  test "default_processors defaults to empty array" do
+    assert_equal [], Perron.configuration.default_processors
   end
 end


### PR DESCRIPTION
Allows configuring processors to run on every markdownify call via:
```ruby
Perron.configure do |config|
  config.default_processors = [MyProcessor, "target_blank"]
end
```

Passing an explicit `process:` argument to markdownify overrides the defaults. Use `Perron.configuration.default_processors + [additional]` in your views if you need to combine defaults with additional per-call processors.

This seems the most flexible solution without being annoying to overide (eg like Rails `default_scope`).

Closes https://github.com/Rails-Designer/perron/issues/123 /cc @ianyamey 