### PR TITLE
Add Perron::Adjacency concern for next/previous navigation

### DIFF
--- a/lib/perron/resource.rb
+++ b/lib/perron/resource.rb
@@ -17,6 +17,7 @@ require "perron/resource/searchable"
 require "perron/resource/separator"
 require "perron/resource/sourceable"
 require "perron/resource/sweeper"
+require "perron/resource/adjacency"
 require "perron/resource/table_of_content"
 
 module Perron
@@ -34,6 +35,7 @@ module Perron
     include Previewable
     include Scopes
     include Sweeper
+    include Adjacency
     include TableOfContent
 
     attr_reader :file_path, :id

--- a/lib/perron/resource/adjacency.rb
+++ b/lib/perron/resource/adjacency.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+module Perron
+  class Resource
+    module Adjacency
+      extend ActiveSupport::Concern
+
+      class_methods do
+        def adjacent_by(position_method, within: {})
+          return unless within.present?
+
+          grouping_method = within.is_a?(Hash) ? within.keys.first : within
+          grouping_order = within.is_a?(Hash) ? within.values.first : nil
+
+          define_method(:next) do
+            resources = self.class.all.sort_by do |resource|
+              group_value = resource.public_send(grouping_method)
+
+              group_order = if grouping_order
+                grouping_order.index(group_value.to_s) || grouping_order.index(group_value.to_sym) || Float::INFINITY
+              else
+                group_value.to_s
+              end
+
+              [group_order, resource.public_send(position_method)]
+            end
+
+            return if (position = resources.index { it.id == id }).nil? || position >= resources.size - 1
+
+            resources[position + 1]
+          end
+
+          define_method(:previous) do
+            resources = self.class.all.sort_by do |resource|
+              group_value = resource.public_send(grouping_method)
+
+              group_order = if grouping_order
+                grouping_order.index(group_value.to_s) || grouping_order.index(group_value.to_sym) || Float::INFINITY
+              else
+                group_value.to_s
+              end
+
+              [group_order, resource.public_send(position_method)]
+            end
+
+            return if (position = resources.index { it.id == id }).nil? || position <= 0
+
+            resources[position - 1]
+          end
+        end
+      end
+
+      included do
+        define_method(:next) do
+          resources = self.class.all
+          return if (position = resources.index { it.id == id }).nil? || position >= resources.size - 1
+
+          resources[position + 1]
+        end
+
+        define_method(:previous) do
+          resources = self.class.all
+          return if (position = resources.index { it.id == id }).nil? || position <= 0
+
+          resources[position - 1]
+        end
+      end
+    end
+  end
+end

--- a/test/dummy/app/content/articles/advanced.md
+++ b/test/dummy/app/content/articles/advanced.md
@@ -1,0 +1,6 @@
+---
+title: Advanced Usage
+description: Advanced topics
+section: content
+position: 2
+---

--- a/test/dummy/app/content/articles/changelog.md
+++ b/test/dummy/app/content/articles/changelog.md
@@ -1,0 +1,6 @@
+---
+title: Changelog
+description: Version history
+section: metadata
+position: 1
+---

--- a/test/dummy/app/content/articles/configuration.md
+++ b/test/dummy/app/content/articles/configuration.md
@@ -1,0 +1,6 @@
+---
+title: Configuration
+description: Configuration stuff
+section: content
+position: 1
+---

--- a/test/dummy/app/content/articles/installation.md
+++ b/test/dummy/app/content/articles/installation.md
@@ -1,0 +1,6 @@
+---
+title: Installation
+description: How to install
+section: getting_started
+position: 1
+---

--- a/test/dummy/app/content/articles/quickstart.md
+++ b/test/dummy/app/content/articles/quickstart.md
@@ -1,0 +1,6 @@
+---
+title: Quick Start
+description: Quick start guide
+section: getting_started
+position: 2
+---

--- a/test/dummy/app/content/changelogs/advanced.md
+++ b/test/dummy/app/content/changelogs/advanced.md
@@ -1,0 +1,7 @@
+---
+title: Advanced Usage
+description: Advanced topics
+section: content
+position: 4
+---
+# Advanced usage

--- a/test/dummy/app/content/changelogs/changelog.md
+++ b/test/dummy/app/content/changelogs/changelog.md
@@ -1,0 +1,7 @@
+---
+title: Changelog
+description: Version history
+section: metadata
+position: 3
+---
+# Changelog

--- a/test/dummy/app/content/changelogs/configuration.md
+++ b/test/dummy/app/content/changelogs/configuration.md
@@ -1,0 +1,7 @@
+---
+title: Configuration
+description: Configuration options
+section: content
+position: 2
+---
+# Configuration guide

--- a/test/dummy/app/content/changelogs/installation.md
+++ b/test/dummy/app/content/changelogs/installation.md
@@ -1,0 +1,7 @@
+---
+title: Installation
+description: How to install
+section: getting_started
+position: 1
+---
+# Installation guide

--- a/test/dummy/app/content/changelogs/quickstart.md
+++ b/test/dummy/app/content/changelogs/quickstart.md
@@ -1,0 +1,7 @@
+---
+title: Quick Start
+description: Quick start guide
+section: getting_started
+position: 5
+---
+# Quick start guide

--- a/test/dummy/app/content/docs/advanced.md
+++ b/test/dummy/app/content/docs/advanced.md
@@ -1,0 +1,7 @@
+---
+title: Advanced Usage
+description: Advanced topics
+section: content
+position: 4
+---
+# Advanced usage

--- a/test/dummy/app/content/docs/changelog.md
+++ b/test/dummy/app/content/docs/changelog.md
@@ -1,0 +1,7 @@
+---
+title: Changelog
+description: Version history
+section: metadata
+position: 3
+---
+# Changelog

--- a/test/dummy/app/content/docs/configuration.md
+++ b/test/dummy/app/content/docs/configuration.md
@@ -1,0 +1,7 @@
+---
+title: Configuration
+description: Configuration options
+section: content
+position: 2
+---
+# Configuration guide

--- a/test/dummy/app/content/docs/installation.md
+++ b/test/dummy/app/content/docs/installation.md
@@ -1,0 +1,7 @@
+---
+title: Installation
+description: How to install
+section: getting_started
+position: 1
+---
+# Installation guide

--- a/test/dummy/app/content/docs/quickstart.md
+++ b/test/dummy/app/content/docs/quickstart.md
@@ -1,0 +1,7 @@
+---
+title: Quick Start
+description: Quick start guide
+section: getting_started
+position: 5
+---
+# Quick start guide

--- a/test/dummy/app/models/content/article.rb
+++ b/test/dummy/app/models/content/article.rb
@@ -1,2 +1,7 @@
 class Content::Article < Perron::Resource
+  SECTIONS = %w[getting_started content metadata]
+
+  delegate :section, :position, to: :metadata
+
+  adjacent_by :position, within: { section: SECTIONS }
 end

--- a/test/dummy/app/models/content/changelog.rb
+++ b/test/dummy/app/models/content/changelog.rb
@@ -1,0 +1,5 @@
+class Content::Changelog < Perron::Resource
+  delegate :section, :position, to: :metadata
+
+  adjacent_by :position, within: :section
+end

--- a/test/dummy/app/models/content/doc.rb
+++ b/test/dummy/app/models/content/doc.rb
@@ -1,0 +1,5 @@
+class Content::Doc < Perron::Resource
+  delegate :section, :position, to: :metadata
+
+  adjacent_by :position
+end

--- a/test/perron/resource/adjacency_test.rb
+++ b/test/perron/resource/adjacency_test.rb
@@ -1,0 +1,90 @@
+require "test_helper"
+
+class Perron::Resource::AdjacencyTest < ActiveSupport::TestCase
+  test "next returns the following resource within same section" do
+    installation = Content::Article.find("installation")
+    quickstart = Content::Article.find("quickstart")
+
+    assert_equal quickstart.id, installation.next.id
+  end
+
+  test "previous returns the previous resource within same section" do
+    quickstart = Content::Article.find("quickstart")
+    installation = Content::Article.find("installation")
+
+    assert_equal installation.id, quickstart.previous.id
+  end
+
+  test "next returns nil for the last resource" do
+    changelog = Content::Article.find("changelog")
+
+    assert_nil changelog.next
+  end
+
+  test "previous returns nil for the first resource" do
+    installation = Content::Article.find("installation")
+
+    assert_nil installation.previous
+  end
+
+  test "next cross-category: last of getting_started goes to first of content" do
+    quickstart = Content::Article.find("quickstart")
+    configuration = Content::Article.find("configuration")
+
+    assert_equal configuration.id, quickstart.next.id
+  end
+
+  test "previous cross-category: first of content goes to last of getting_started" do
+    configuration = Content::Article.find("configuration")
+    quickstart = Content::Article.find("quickstart")
+
+    assert_equal quickstart.id, configuration.previous.id
+  end
+
+  test "next cross-category: last of content goes to first of metadata" do
+    advanced = Content::Article.find("advanced")
+    changelog = Content::Article.find("changelog")
+
+    assert_equal changelog.id, advanced.next.id
+  end
+
+  test "previous cross-category: first of metadata goes to last of content" do
+    changelog = Content::Article.find("changelog")
+    advanced = Content::Article.find("advanced")
+
+    assert_equal advanced.id, changelog.previous.id
+  end
+
+  test "flat: next returns the following resource" do
+    installation = Content::Doc.find("installation")
+    quickstart = Content::Doc.find("quickstart")
+
+    assert_equal quickstart.id, installation.next.id
+  end
+
+  test "flat: next returns nil for the last resource" do
+    quickstart = Content::Doc.find("quickstart")
+
+    assert_nil quickstart.next
+  end
+
+  test "flat: previous returns previous in natural order" do
+    installation = Content::Doc.find("installation")
+    configuration = Content::Doc.find("configuration")
+
+    assert_equal configuration.id, installation.previous.id
+  end
+
+  test "alphabetical: groups by section and orders sections alphabetically" do
+    configuration = Content::Changelog.find("configuration")
+    advanced = Content::Changelog.find("advanced")
+
+    assert_equal advanced.id, configuration.next.id
+  end
+
+  test "alphabetical: previous returns nil for first section, first item" do
+    configuration = Content::Changelog.find("configuration")
+
+    assert_nil configuration.previous
+  end
+end


### PR DESCRIPTION
Resource classes now have previous/next methods that return the previous/next resource based on the filenames (eg. alphabetically).

To customise, eg. order by, eg. position and by group (eg. category):
- `adjacent_by :position, within: :category` (where category could be any available method, default order is alphabetically)
- `adjacent_by :position, within: { category: %w[getting_started content metadata] }` if you need to order grouping (categories) too
- Returns nil at boundaries (first/last resource)
- Cross-group traversal: last of group A → first of group B (and nil at last resource of last group)

Closes: https://github.com/Rails-Designer/perron/issues/119