### PR TITLE
feat(resource): support `erb: false` in frontmatter (#186)

### DIFF
--- a/lib/perron/resource.rb
+++ b/lib/perron/resource.rb
@@ -117,6 +117,8 @@ module Perron
     end
 
     def erb_processing?
+      return false if metadata.erb == false
+
       @file_path.ends_with?(".erb") || metadata.erb == true
     end
   end

--- a/test/dummy/app/content/pages/no-erb.erb
+++ b/test/dummy/app/content/pages/no-erb.erb
@@ -1,0 +1,5 @@
+---
+erb: false
+---
+
+<%= 'this should not be evaluated' %>

--- a/test/perron/resource_test.rb
+++ b/test/perron/resource_test.rb
@@ -54,6 +54,15 @@ class Perron::Site::ResourceTest < ActiveSupport::TestCase
     assert_match "And one more paragraph for good measure", content
   end
 
+  test "#content skips ERB processing when frontmatter sets `erb: false` on an .erb file" do
+    no_erb_page = Content::Page.new("test/dummy/app/content/pages/no-erb.erb")
+
+    content = no_erb_page.content
+
+    # ERB tags should be preserved verbatim instead of evaluated.
+    assert_match(/<%=\s*'this should not be evaluated'\s*%>/, content)
+  end
+
   test "#metadata returns metadata hash" do
     assert_kind_of Hash, @page.metadata
   end


### PR DESCRIPTION
## Summary

Resolves #186.

\`erb: true\` in a markdown resource's frontmatter flips on ERB processing for the file. The opposite direction wasn't supported: an \`.erb\`-suffixed file always went through \`Renderer.erb\`, regardless of any \`erb:\` value in its frontmatter. \`erb_processing?\` only checked for \`metadata.erb == true\`, so an explicit \`erb: false\` was indistinguishable from the key being absent.

## Changes

- \`lib/perron/resource.rb\`: \`erb_processing?\` now early-returns \`false\` when \`metadata.erb == false\`, before the \`.erb\` suffix check.
- \`test/dummy/app/content/pages/no-erb.erb\`: new fixture, an \`.erb\` page with \`erb: false\` frontmatter and a literal \`<%= '...' %>\` tag.
- \`test/perron/resource_test.rb\`: asserts the ERB tag in the new fixture is preserved verbatim by \`#content\` (i.e. goes through \`render_inline_erb\` instead of \`Renderer.erb\`).

## Behavior matrix

| File extension | \`erb:\` in frontmatter | \`erb_processing?\` (before -> after) |
| --- | --- | --- |
| \`.md\` | absent | \`false\` -> \`false\` (unchanged) |
| \`.md\` | \`true\` | \`true\` -> \`true\` (unchanged) |
| \`.md\` | \`false\` | \`false\` -> \`false\` (unchanged) |
| \`.erb\` | absent | \`true\` -> \`true\` (unchanged) |
| \`.erb\` | \`true\` | \`true\` -> \`true\` (unchanged) |
| \`.erb\` | \`false\` | \`true\` -> \`false\` (the fix) |

## Test plan

- \`bundle exec rake test\` (need Ruby 3.4+; I don't have it locally, so I verified the Ruby syntax of the changed blocks under 2.6 and reasoned about the \`#content\` flow: when \`erb_processing?\` returns \`false\`, the method falls through to \`render_inline_erb\`, which only matches the \`erbify do ... end\` pattern. A bare \`<%= '...' %>\` tag won't match and is preserved as source text - which is exactly what the new test asserts.)

Fixes #186