### PR TITLE
Support flat YAML arrays in data sources

### DIFF
--- a/lib/perron/data_source.rb
+++ b/lib/perron/data_source.rb
@@ -66,11 +66,13 @@ module Perron
       end
 
       data.map.with_index do |item, index|
-        unless item.is_a?(Hash)
-          raise Errors::DataParseError, "Item at index #{index} in `#{@file_path}` must be a hash/object, got #{item.class}"
+        if item.is_a?(Hash)
+          Item.new(item, identifier: @identifier)
+        elsif item.is_a?(String)
+          item
+        else
+          raise Errors::DataParseError, "Item at index #{index} in `#{@file_path}` must be a hash/object or string, got #{item.class}"
         end
-
-        Item.new(item, identifier: @identifier)
       end
     end
 

--- a/test/dummy/app/content/data/services.yml
+++ b/test/dummy/app/content/data/services.yml
@@ -1,0 +1,3 @@
+- Custom design based on our templates
+- Copywriting services
+- Dedicated project manager

--- a/test/perron/data_test.rb
+++ b/test/perron/data_test.rb
@@ -266,4 +266,10 @@ class Perron::Site::DataTest < ActiveSupport::TestCase
 
     assert_includes error.message, "Invalid YAML syntax"
   end
+
+  test "loads YAML file with flat array of strings" do
+    data = Content::Data.new("services")
+
+    assert_equal ["Custom design based on our templates", "Copywriting services", "Dedicated project manager"], data.to_a
+  end
 end


### PR DESCRIPTION
Data sources now accept YAML files with a flat array of strings, e.g.
```
- Custom design based on our templates
- Copywriting services
- Dedicated project manager
```

Previously a key/value set up was required.