### PR TITLE
Exclude README.md from build

### DIFF
--- a/lib/perron/collection.rb
+++ b/lib/perron/collection.rb
@@ -52,6 +52,7 @@ module Perron
 
       Dir.glob("#{@collection_path}/**/*.*")
         .select { allowed_extensions.include?(File.extname(it)) }
+        .reject { File.basename(it, ".*").downcase == "readme" }
         .map { resource_class.new(it) }
     end
   end


### PR DESCRIPTION
Just stumbled upon a weird issue where I added a README.md to a collection and it caused all sorts of issues.