### PR TITLE
Fix concierge new content command

### DIFF
--- a/app/views/perron/concierge/show.html.erb
+++ b/app/views/perron/concierge/show.html.erb
@@ -211,7 +211,7 @@
             <code>bin/rails generate content Post --new "My first post"</code>
 
             <%= form_with url: perron_run_command_path do |form| %>
-              <%= form.hidden_field :command, value: 'bin/rails generate content Post --new "My first post"' %>
+              <%= form.hidden_field :command, value: 'bin/rails generate content Post --new' %>
 
               <% if File.file?("app/content/posts/untitled.md") %>
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" fill="currentColor"><path d="M128,24A104,104,0,1,0,232,128,104.11,104.11,0,0,0,128,24Zm45.66,85.66-56,56a8,8,0,0,1-11.32,0l-24-24a8,8,0,0,1,11.32-11.32L112,148.69l50.34-50.35a8,8,0,0,1,11.32,11.32Z"/></svg>


### PR DESCRIPTION
Without a template title is not used, so removing it.