### PR TITLE
Raise more useful error on YAML syntax errors

### DIFF
--- a/lib/perron/site/validate.rb
+++ b/lib/perron/site/validate.rb
@@ -36,7 +36,11 @@ module Perron
       def validate_collection(collection)
         collection.resources.each do |resource|
           resource.validate ? success : failed(resource)
+        rescue Psych::SyntaxError => error
+          render_yaml error, resource.file_path
         end
+      rescue Psych::SyntaxError => error
+        render_yaml error, "unknown"
       end
 
       def success = print "#{GREEN}.#{RESET}"
@@ -44,13 +48,22 @@ module Perron
       def failed(resource)
         print "#{RED}F#{RESET}"
 
-        errors = []
+        @failures << Failure.new(
+          identifier: resource.file_path,
+          errors: resource.errors.respond_to?(:full_messages) ? resource.errors.full_messages : []
+        )
+      end
 
-        if resource.respond_to?(:errors) && resource.errors.respond_to?(:full_messages) && resource.errors.any?
-          errors = resource.errors.full_messages
-        end
+      def render_yaml(error, identifier)
+        print "#{RED}F#{RESET}"
 
-        @failures << Failure.new(identifier: resource.file_path, errors: errors)
+        line_info = error.line ? " at line #{error.line}" : ""
+        column_info = error.column ? ", column #{error.column}" : ""
+
+        @failures << Failure.new(
+          identifier: identifier,
+          errors: ["Invalid YAML#{line_info}#{column_info}: #{error.problem}"]
+        )
       end
 
       def failures_report

--- a/test/perron/site/validate_test.rb
+++ b/test/perron/site/validate_test.rb
@@ -1,0 +1,33 @@
+require "test_helper"
+
+class Perron::Site::ValidateTest < ActiveSupport::TestCase
+  def test_prints_failure_for_yaml_syntax_error
+    content_dir = Rails.root.join("app/content/pages")
+    syntax_error_file = content_dir.join("syntax-error.md")
+
+    File.write(syntax_error_file, <<~CONTENT)
+      ---
+      title: Syntax Error
+      invalid: yaml: here
+      ---
+      Content
+    CONTENT
+
+    validator = Perron::Site::Validate.new(collections: [Content::Page.collection])
+
+    output = capture_io { validator.validate }
+
+    assert_match /Invalid YAML/, output.join
+    assert_match /line 2/, output.join
+  ensure
+    File.delete(syntax_error_file) if File.exist?(syntax_error_file)
+  end
+
+  def test_prints_failure_for_validation_errors
+    validator = Perron::Site::Validate.new(collections: [Content::Page.collection])
+
+    output = capture_io { validator.validate }
+
+    assert_match /failures/, output.join
+  end
+end


### PR DESCRIPTION
Ever had a syntax error in YAML? You would get a useless error like:
```bash
Psych::SyntaxError: (<unknown>): mapping values are not allowed in this context at line 2 column 17 (Psych::SyntaxError)
```

In this example that was because of this frontmatter: `title: Meet Mata: live reload for Rack Apps`. Note the `:` in the title. 

Now when running the `bin/rails perron:validate` task, the output is a bit more helpful, eg
```bash
rails perron:validate
....................................................................................................................................................................................................................F......................................................................................................................................
Resource: /Users/e/Tresorit/Code/railsdesigner/site/app/content/posts/0000-00-00-meet-mata.md
  - Invalid YAML at line 2, column 17: mapping values are not allowed in this context
````