### PR TITLE
Add destroy and destroy_all to Perron::Resource

### DIFF
--- a/lib/perron/resource.rb
+++ b/lib/perron/resource.rb
@@ -96,6 +96,10 @@ module Perron
       slug == "/"
     end
 
+    def destroy
+      File.delete(@file_path) and self
+    end
+
     private
 
     ID_LENGTH = 8

--- a/lib/perron/resource/class_methods.rb
+++ b/lib/perron/resource/class_methods.rb
@@ -44,6 +44,10 @@ module Perron
 
         def root = all.find(&:root?)
 
+        def destroy_all
+          all.each(&:destroy)
+        end
+
         def model_name
           @model_name ||= ActiveModel::Name.new(self, nil, name.demodulize.to_s)
         end

--- a/test/dummy/app/models/content/zombie.rb
+++ b/test/dummy/app/models/content/zombie.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class Content::Zombie < Perron::Resource
+end

--- a/test/perron/resource/class_methods_test.rb
+++ b/test/perron/resource/class_methods_test.rb
@@ -151,4 +151,13 @@ class Perron::Resource::ClassMethodsTest < ActiveSupport::TestCase
     assert_instance_of Perron::Relation, posts
     assert_equal 2, posts.size
   end
+
+  test ".destroy_all deletes all resource files and returns array of deleted resources" do
+    existing_count = Content::Zombie.count
+
+    deleted = Content::Zombie.destroy_all
+
+    assert_equal existing_count, deleted.size
+    assert_equal 0, Content::Zombie.count
+  end
 end

--- a/test/perron/resource_test.rb
+++ b/test/perron/resource_test.rb
@@ -145,4 +145,16 @@ class Perron::Site::ResourceTest < ActiveSupport::TestCase
 
     assert_equal :not_found, result[:status]
   end
+
+  test "#destroy deletes the resource file and returns self" do
+    test_file = "test/dummy/app/content/zombies/destroy-test-zombie.md"
+    File.write(test_file, "---\ntitle: Test Zombie\n---\nTest content")
+
+    zombie = Content::Zombie.new(test_file)
+
+    result = zombie.destroy
+
+    assert_equal zombie, result
+    assert_not File.exist?(test_file)
+  end
 end


### PR DESCRIPTION
Adds destroy and destroy_all methods for deleting resource content files.

```bash
Content::Post.find("slug").destroy  # => deletes app/content/posts/slug.md
Content::Post.destroy_all  # => deletes app/content/posts/*.md
```

To me this is mostly syntactic sugar similar to how Active Record's `destroy` works (so you do not need to use SQL to delete a table row). 

Niche or does it has some good use cases? 