### PR TITLE
Tweaked metatags/frontmatter order 

### DIFF
--- a/app/helpers/perron/meta_tags_helper.rb
+++ b/app/helpers/perron/meta_tags_helper.rb
@@ -2,16 +2,10 @@
 
 module Perron
   module MetaTagsHelper
-    def meta_tags(options = {}) = Perron::Metatags.new(resource.metadata).render(options)
+    def meta_tags(options = {})
+      metadata = (@metadata || {}).merge(@resource&.metadata || {})
 
-    private
-
-    Resource = Data.define(:path, :collection, :metadata, :published_at)
-
-    def resource
-      return Resource.new(request.path, nil, @metadata, nil) if @metadata.present?
-
-      @resource || Resource.new(request.path, nil, {}, nil)
+      Perron::Metatags.new(metadata).render(options)
     end
   end
 end

--- a/lib/perron/resource/metadata.rb
+++ b/lib/perron/resource/metadata.rb
@@ -3,22 +3,28 @@
 module Perron
   class Resource
     class Metadata
-      def initialize(resource:, frontmatter:, collection:)
+      def initialize(resource:, frontmatter:, collection:, controller_metadata: {})
         @resource = resource
         @frontmatter = frontmatter&.deep_symbolize_keys || {}
         @collection = collection
+        @controller_metadata = controller_metadata
         @config = Perron.configuration
       end
 
       def data
         @data ||= ActiveSupport::OrderedOptions
           .new
-          .merge(apply_fallbacks_and_defaults(to: merged_site_collection_resource_frontmatter))
+          .merge(apply_fallbacks_and_defaults(to: merged_metadata))
       end
 
       private
 
-      def merged_site_collection_resource_frontmatter = site_data.merge(collection_data).merge(@frontmatter)
+      def merged_metadata
+        site_data
+          .merge(collection_data)
+          .merge(@controller_metadata)
+          .merge(@frontmatter)
+      end
 
       def apply_fallbacks_and_defaults(to:)
         to[:title] ||= @config.site_name || Rails.application.name.underscore.camelize

--- a/test/helpers/metatags_helper_test.rb
+++ b/test/helpers/metatags_helper_test.rb
@@ -11,4 +11,18 @@ class MetaTagsHelperTest < ActionView::TestCase
     result = meta_tags
     assert result, "Expected meta_tags to return a truthy value"
   end
+
+  test "@metadata from controller is overridden by frontmatter" do
+    def request.path; "/test-path"; end
+
+    post = Content::Post.new("test/dummy/app/content/posts/2023-05-15-sample-post.md")
+
+    @resource = post
+    @metadata = { title: "Controller Override" }
+
+    html = meta_tags
+
+    assert_includes html, "<title>Sample Post", "Frontmatter title should win over @metadata"
+    refute_includes html, "Controller Override", "@metadata title should not appear"
+  end
 end

--- a/test/perron/site/validate_test.rb
+++ b/test/perron/site/validate_test.rb
@@ -17,8 +17,8 @@ class Perron::Site::ValidateTest < ActiveSupport::TestCase
 
     output = capture_io { validator.validate }
 
-    assert_match /Invalid YAML/, output.join
-    assert_match /line 2/, output.join
+    assert_match(/Invalid YAML/, output.join)
+    assert_match(/line 2/, output.join)
   ensure
     File.delete(syntax_error_file) if File.exist?(syntax_error_file)
   end
@@ -28,6 +28,6 @@ class Perron::Site::ValidateTest < ActiveSupport::TestCase
 
     output = capture_io { validator.validate }
 
-    assert_match /failures/, output.join
+    assert_match(/failures/, output.join)
   end
 end


### PR DESCRIPTION
Changed order such that resource frontmatter takes precedence over controller action's `@metadata = {}`