### PR TITLE
Add build hooks for before/after actions

### DIFF
--- a/lib/perron/configuration.rb
+++ b/lib/perron/configuration.rb
@@ -53,6 +53,9 @@ module Perron
 
       @config.metadata = ActiveSupport::OrderedOptions.new
       @config.metadata.title_separator = " — "
+
+      @config.before_build = nil
+      @config.after_build = nil
     end
 
     def input = Rails.root.join("app", "content")

--- a/lib/perron/site/builder.rb
+++ b/lib/perron/site/builder.rb
@@ -16,6 +16,8 @@ module Perron
       end
 
       def build
+        run_hook(:before_build)
+
         if Perron.configuration.mode.standalone?
           puts "🧹 Cleaning previous build…"
 
@@ -35,6 +37,10 @@ module Perron
         output_preview_urls
 
         puts "\n✅ Build complete"
+      rescue
+        raise
+      ensure
+        run_hook(:after_build)
       end
 
       private
@@ -56,6 +62,26 @@ module Perron
           previewable_resources.each do |resource|
             puts "   #{Rails.application.routes.url_helpers.polymorphic_url(resource, **Perron.configuration.default_url_options)}"
           end
+        end
+      end
+
+      def run_hook(name)
+        return unless (hook = Perron.configuration.public_send(name))
+
+        context = Context.new(
+          output_path: @output_path.to_s,
+          mode: Perron.configuration.mode
+        )
+
+        hook.call(context)
+      end
+
+      class Context
+        attr_reader :output_path, :mode
+
+        def initialize(output_path:, mode:)
+          @output_path = output_path
+          @mode = mode
         end
       end
     end

--- a/test/perron/build_hooks_test.rb
+++ b/test/perron/build_hooks_test.rb
@@ -1,0 +1,21 @@
+require "test_helper"
+
+class Perron::BuildHooksTest < ActiveSupport::TestCase
+  test "configuration has before_build callback" do
+    assert_respond_to Perron.configuration, :before_build
+  end
+
+  test "configuration has after_build callback" do
+    assert_respond_to Perron.configuration, :after_build
+  end
+
+  test "before_build failure aborts build" do
+    Perron.configure do |config|
+      config.before_build = ->(context) { raise "pre-build validation failed" }
+    end
+
+    assert_raises(RuntimeError) do
+      Perron::Site.build
+    end
+  end
+end


### PR DESCRIPTION
Configure `before_build` and `after_build` callbacks to run logic before/after the build process.
```ruby
Perron.configure do |config|
  config.before_build = ->(context) {
    # do whatever before build
  }

  config.after_build = ->(context) {
    # do whatever after build succeeded
  }
end
```