### PR TITLE
Remove beam_up as hard dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,6 @@ PATH
   remote: .
   specs:
     perron (1.0.0)
-      beam_up
       csv
       json
       mata (~> 0.8.0)
@@ -88,30 +87,7 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.3)
-    aws-eventstream (1.4.0)
-    aws-partitions (1.1251.0)
-    aws-sdk-core (3.247.0)
-      aws-eventstream (~> 1, >= 1.3.0)
-      aws-partitions (~> 1, >= 1.992.0)
-      aws-sigv4 (~> 1.9)
-      base64
-      bigdecimal
-      jmespath (~> 1, >= 1.6.1)
-      logger
-    aws-sdk-kms (1.126.0)
-      aws-sdk-core (~> 3, >= 3.247.0)
-      aws-sigv4 (~> 1.5)
-    aws-sdk-s3 (1.223.0)
-      aws-sdk-core (~> 3, >= 3.247.0)
-      aws-sdk-kms (~> 1)
-      aws-sigv4 (~> 1.5)
-    aws-sigv4 (1.12.1)
-      aws-eventstream (~> 1, >= 1.0.2)
     base64 (0.3.0)
-    beam_up (0.6.0)
-      aws-sdk-s3 (~> 1.0)
-      rexml (~> 3.0)
-      rubyzip (~> 3.0)
     benchmark (0.4.1)
     bigdecimal (3.2.2)
     builder (3.3.0)
@@ -143,7 +119,6 @@ GEM
       pp (>= 0.6.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
-    jmespath (1.6.2)
     json (2.12.2)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
@@ -252,7 +227,6 @@ GEM
     regexp_parser (2.10.0)
     reline (0.6.1)
       io-console (~> 0.5)
-    rexml (3.4.4)
     rouge (4.6.0)
     rubocop (1.75.8)
       json (~> 2.3)
@@ -273,7 +247,6 @@ GEM
       rubocop (>= 1.75.0, < 2.0)
       rubocop-ast (>= 1.38.0, < 2.0)
     ruby-progressbar (1.13.0)
-    rubyzip (3.3.0)
     securerandom (0.4.1)
     standard (1.50.0)
       language_server-protocol (~> 3.17.0.2)

--- a/lib/perron/install/deploy.yml
+++ b/lib/perron/install/deploy.yml
@@ -1,5 +1,6 @@
 # Deploy configuration for Perron
-# See: https://perron.railsdesigner.com/docs/deploy/
+# Requires Beam Up (`bundle add beam_up`)
+# See also: https://perron.railsdesigner.com/docs/deploy/
 
 # Uncomment and configure your provider:
 # provider: netlify

--- a/lib/perron/install/initializer.rb.tt
+++ b/lib/perron/install/initializer.rb.tt
@@ -5,13 +5,6 @@ Perron.configure do |config|
   # The build mode for Perron. Can be :standalone (SSG, default) or :integrated (alongside your Rails app)
   # config.mode = :standalone
 
-  # Make sure to add beam_up, `bundle add beam_up`
-  # Perron.configure do |config|
-  #  config.deploy.provider = :netlify
-  #  config.deploy.netlify.access_token = "ACCESS_TOKEN"
-  #  config.deploy.netlify.site_id = "SITE_ID"
-  # end
-
   # Enable Live Reload with DOM Morphing in development
   # config.live_reload = true
 

--- a/lib/perron/tasks/deploy.rake
+++ b/lib/perron/tasks/deploy.rake
@@ -1,4 +1,15 @@
-require "beam_up"
+begin
+  require "beam_up"
+rescue LoadError
+  abort <<~MSG
+    Beam Up is required for the deploy task to run.
+
+    Add it to your Gemfile:
+      gem "beam_up"
+
+    See for more: https://perron.railsdesigner.com/docs/deploy/
+  MSG
+end
 
 namespace :perron do
   desc "Deploy static site using Beam Up"

--- a/perron.gemspec
+++ b/perron.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "rails", ">= 7.2.0"
   spec.add_dependency "mata", "~> 0.8.0"
-  spec.add_dependency "beam_up"
 
   spec.add_runtime_dependency "csv"
   spec.add_runtime_dependency "json"


### PR DESCRIPTION
This removes beam_up as a default gem. This lessen the dependencies added (beam_up requires a few as well).

Need to run `bundle add beam_up` explicitely; similar to one of the markdown parsers.

Related: https://github.com/Rails-Designer/perron/pull/199