### PR TITLE
Adds a mode option for single source definitions

### DIFF
--- a/lib/perron/resource/sourceable.rb
+++ b/lib/perron/resource/sourceable.rb
@@ -5,6 +5,11 @@ module Perron
     module Sourceable
       extend ActiveSupport::Concern
 
+      MODES = {
+        single: ->(dataset) { dataset.zip },
+        combinations: ->(dataset) { dataset.to_a.combination(2).to_a }
+      }
+
       class_methods do
         def sources(*arguments)
           @source_definitions = parsed(*arguments)
@@ -32,7 +37,7 @@ module Perron
         def generate_from_sources!
           return unless source_backed?
 
-          combinations.each do |combo|
+          derive.each do |combo|
             content = content_with combo
             filename = filename_with combo
 
@@ -48,7 +53,7 @@ module Perron
         def parsed(*arguments)
           return {} if arguments.empty?
 
-          arguments.flat_map do |argument|
+          definitions = arguments.flat_map do |argument|
             case argument
             when Hash
               argument.to_a
@@ -58,11 +63,39 @@ module Perron
               [[argument, {primary_key: :id}]]
             end
           end.to_h
+
+          if definitions.values.any? { it[:mode] }
+            raise ArgumentError, "mode is only supported for single-source definitions" if definitions.size > 1
+          end
+
+          definitions
         end
 
-        def combinations
+        def derive
           datasets = source_names.map { resolve it }
 
+          if single_source_with_mode?
+            derive_from_single_source(datasets.first)
+          else
+            derive_from_multiple_sources(datasets)
+          end
+        end
+
+        def derive_from_single_source(dataset)
+          source_name = source_names.first
+          mode = source_definitions[source_name][:mode] || :single
+          method = MODES[mode.to_sym] || raise(ArgumentError, "Unknown mode: #{mode}")
+
+          method.call(dataset).each do |combo|
+            primary_key = source_definitions[source_name][:primary_key] || :id
+
+            combo.each do |item|
+              raise Errors::DataParseError, "Primary key `#{primary_key}` is nil for row" if item.public_send(primary_key).nil?
+            end
+          end
+        end
+
+        def derive_from_multiple_sources(datasets)
           datasets.first.product(*datasets[1..]).each do |combo|
             combo.each_with_index do |item, index|
               name = source_names[index]
@@ -74,18 +107,37 @@ module Perron
         end
 
         def content_with(combo)
-          data = source_names.each.with_index.to_h { |name, index| [name, combo[index]] }
+          data = if single_source_with_mode?
+            source_name = source_names.first
+            names = source_definitions[source_name][:as]&.map(&:to_sym) || (1..combo.size).map { :"#{source_name}_#{it}" }
+
+            combo.each_with_index.to_h { |item, index| [names[index], item] }
+          else
+            source_names.each_with_index.to_h { |name, index| [name, combo[index]] }
+          end
+
           source = Source.new(data)
 
           source_template(source)
         end
 
         def filename_with(combo)
-          source_names.each_with_index.map do |name, index|
-            primary_key = source_definitions[name][:primary_key]
+          if single_source_with_mode?
+            source_name = source_names.first
+            primary_key = source_definitions[source_name][:primary_key] || :id
 
-            combo[index].public_send(primary_key)
-          end.join("-")
+            combo.map { it.public_send(primary_key) }.join("-")
+          else
+            source_names.each_with_index.map do |name, index|
+              primary_key = source_definitions[name][:primary_key]
+
+              combo[index].public_send(primary_key)
+            end.join("-")
+          end
+        end
+
+        def single_source_with_mode?
+          source_names.one? && source_definitions[source_names.first][:mode]
         end
 
         def output_dir = Perron.configuration.input.join(model_name.collection)

--- a/test/dummy/app/content/data/comparisons.csv
+++ b/test/dummy/app/content/data/comparisons.csv
@@ -1,0 +1,4 @@
+code,name,price,category
+a,Tool A,100,category_a
+b,Tool B,200,category_b
+c,Tool C,150,category_a

--- a/test/dummy/app/models/content/comparison.rb
+++ b/test/dummy/app/models/content/comparison.rb
@@ -1,0 +1,16 @@
+class Content::Comparison < Perron::Resource
+  source comparisons: { primary_key: :code, mode: :combinations }
+
+  def self.source_template(source)
+    <<~TEMPLATE
+    ---
+    comparison_1_code: #{source.comparisons_1.code}
+    comparison_2_code: #{source.comparisons_2.code}
+    ---
+
+    # #{source.comparisons_1.name} vs #{source.comparisons_2.name}
+
+    Price difference: $#{source.comparisons_1.price.to_i - source.comparisons_2.price.to_i}
+    TEMPLATE
+  end
+end

--- a/test/perron/resource/sourceable_test.rb
+++ b/test/perron/resource/sourceable_test.rb
@@ -7,7 +7,9 @@ class Perron::Resource::SourceableTest < ActiveSupport::TestCase
   end
 
   teardown do
-    FileUtils.rm_rf(@output_dir) if @output_dir.exist?
+    [Rails.root.join("app/content/products"), Rails.root.join("app/content/comparisons")].each do |dir|
+      FileUtils.rm_rf(dir) if dir.exist?
+    end
   end
 
   test ".sources sets source names and definitions" do
@@ -87,7 +89,7 @@ class Perron::Resource::SourceableTest < ActiveSupport::TestCase
       end
     end
 
-    combinations = test_class.send(:combinations)
+    combinations = test_class.send(:derive)
 
     assert_equal 2, combinations.length
     assert_equal "product-1", combinations.first.first.id
@@ -106,7 +108,7 @@ class Perron::Resource::SourceableTest < ActiveSupport::TestCase
       end
     end
 
-    combinations = test_class.send(:combinations)
+    combinations = test_class.send(:derive)
 
 assert_equal 1, combinations.length
     assert_equal "product-1", combinations.first.first.id
@@ -122,10 +124,144 @@ assert_equal 1, combinations.length
     end
 
     error = assert_raises Perron::Errors::DataParseError do
-      test_class.send(:combinations)
+      test_class.send(:derive)
     end
 
     assert_includes error.message, "Primary key"
     assert_includes error.message, "id"
+  end
+
+  test ".source with mode: :combinations parses correctly" do
+    test_class = Class.new(Perron::Resource) do
+      source comparisons: { primary_key: :code, mode: :combinations }
+
+      def self.source_template(source)
+        "test"
+      end
+    end
+
+    assert_equal :code, test_class.source_definitions[:comparisons][:primary_key]
+    assert_equal :combinations, test_class.source_definitions[:comparisons][:mode]
+  end
+
+  test "sources with mode option raises ArgumentError" do
+    error = assert_raises ArgumentError do
+      Class.new(Perron::Resource) do
+        sources :countries, products: { primary_key: :code, mode: :combinations }
+
+        def self.source_template(source)
+          "test"
+        end
+      end
+    end
+
+    assert_includes error.message, "mode is only supported for single-source definitions"
+  end
+
+  test ".derive with mode: :combinations generates n*(n-1)/2 pairs" do
+    test_class = Class.new(Perron::Resource) do
+      source comparisons: { primary_key: :code, mode: :combinations }
+
+      def self.source_template(source)
+        "test"
+      end
+    end
+
+    pairs = test_class.send(:derive).to_a
+
+    assert_equal 3, pairs.length
+    assert_equal ["a", "b"], pairs[0].map(&:code)
+    assert_equal ["a", "c"], pairs[1].map(&:code)
+    assert_equal ["b", "c"], pairs[2].map(&:code)
+  end
+
+  test ".derive with mode: :single returns one item per row" do
+    test_class = Class.new(Perron::Resource) do
+      source products: { primary_key: :id, mode: :single }
+
+      def self.source_template(source)
+        "test"
+      end
+    end
+
+    items = test_class.send(:derive).to_a
+
+    assert_equal 2, items.length
+    assert_equal ["1"], items[0].map(&:id)
+    assert_equal ["2"], items[1].map(&:id)
+  end
+
+  test ".derive with unknown mode raises ArgumentError" do
+    test_class = Class.new(Perron::Resource) do
+      source comparisons: { primary_key: :code, mode: :invalid }
+
+      def self.source_template(source)
+        "test"
+      end
+    end
+
+    error = assert_raises ArgumentError do
+      test_class.send(:derive)
+    end
+
+    assert_includes error.message, "Unknown mode"
+  end
+
+  test ".generate_from_sources! with mode: :combinations creates correct files" do
+    @output_dir = Rails.root.join("app/content/comparisons")
+    FileUtils.mkdir_p(@output_dir)
+
+    Content::Comparison.generate_from_sources!
+
+    assert_path_exists @output_dir.join("a-b.erb")
+    assert_path_exists @output_dir.join("a-c.erb")
+    assert_path_exists @output_dir.join("b-c.erb")
+    refute_path_exists @output_dir.join("b-a.erb")
+  end
+
+  test ".generate_from_sources! with mode: :combinations writes correct frontmatter" do
+    @output_dir = Rails.root.join("app/content/comparisons")
+    FileUtils.mkdir_p(@output_dir)
+
+    Content::Comparison.generate_from_sources!
+
+    content = File.read(@output_dir.join("a-b.erb"))
+
+    assert_match(/comparison_1_code: a/, content)
+    assert_match(/comparison_2_code: b/, content)
+  end
+
+  test ".generate_from_sources! with mode: :combinations generates correct template content" do
+    @output_dir = Rails.root.join("app/content/comparisons")
+    FileUtils.mkdir_p(@output_dir)
+
+    Content::Comparison.generate_from_sources!
+
+    content = File.read(@output_dir.join("a-b.erb"))
+
+    assert_match(/Tool A vs Tool B/, content)
+    assert_match(/Price difference: \$-100/, content)
+  end
+
+test ".source with mode: :combinations and :as option uses custom names" do
+    test_class = Class.new(Perron::Resource) do
+      source comparisons: { primary_key: :code, mode: :combinations, as: [:left, :right] }
+
+      def self.source_template(source)
+        "test"
+      end
+    end
+
+    pairs = test_class.send(:derive).to_a
+
+    source_name = test_class.source_names.first
+    source_defs = test_class.source_definitions[source_name]
+    names = source_defs[:as]&.map(&:to_sym) || (1..pairs.first.size).map { :"#{source_name}_#{it}" }
+    data = pairs.first.each_with_index.to_h { |item, index| [names[index], item] }
+
+    assert_includes data.keys, :left
+    assert_includes data.keys, :right
+    refute_includes data.keys, :comparisons_1
+    refute_includes data.keys, :comparisons_2
   end
 end


### PR DESCRIPTION
Assuming a `app/content/data/tools.{csv,json,yaml}` data source.

Usage:
```ruby
source tools: { mode: :combinations }
# Access: tools_1, tools_2

source tools: { mode: :combinations, as: [:left, :right] }
# Access: left, right
```

Future modes (extensible via MODES hash):
- :permutations (ordered pairs: A-B and B-A)
- :triplets (3-way combinations: A-B-C, A-B-D, etc.)
- :sliding (consecutive pairs: A-B, B-C, C-D)
- etc