### PR TITLE
Make provider optional for deploy:init

### DIFF
--- a/lib/perron/tasks/deploy.rake
+++ b/lib/perron/tasks/deploy.rake
@@ -53,18 +53,9 @@ namespace :perron do
         MSG
       end
 
-      provider = arguments[:provider]
+      path = BeamUp.init!(arguments[:provider], config_file: "config/deploy.yml")
 
-      unless provider
-        puts "Usage: rake perron:deploy:init[provider]"
-        puts "Available: #{BeamUp::PROVIDERS.keys.reject { it == "transporter" }.sort.join(", ")}"
-
-        exit 1
-      end
-
-      path = BeamUp.init!(provider, config_file: "config/deploy.yml")
-
-      puts "Configured #{provider} in #{path}"
+      puts "Configured Beam Up in #{path}"
     end
   end
 end


### PR DESCRIPTION
Beam up has support for optional provider for init; it will show a list of providers if none given.